### PR TITLE
docs: 프로젝트 / 프로젝트 매출 계획 / 프로젝트 투입 / 프로젝트 매출 집계 도메인 모델 문서 작성

### DIFF
--- a/docs/도메인모델.md
+++ b/docs/도메인모델.md
@@ -246,6 +246,7 @@ _Aggregate Root_
 
 - `id`: `UUID` 고유 식별자 (AbstractEntity)
 - `partyId`: `UUID` 협력사 ID (not null)
+- `leadDepartmentId` : UUID 주관 부서 ID (not null, 손익 귀속 부서)
 - `code`: `String` 프로젝트 코드 (길이 최대 32, not null, unique)
 - `name`: `String` 프로젝트명 (길이 최대 100, not null)
 - `description`: `String` 프로젝트 설명 (길이 최대 500, nullable)
@@ -267,6 +268,7 @@ _Aggregate Root_
 - 협력사 ID는 유효한 협력사여야 함
 - 프로젝트 종료일은 시작일 이후여야 함
 - Soft Delete 지원
+- 프로젝트의 총 계약 금액은 하위 매출 계획(ProjectRevenuePlan)들의 합과 일치해야 함 (검증 로직 필요)
 
 ### ProjectStatus
 
@@ -274,41 +276,42 @@ _enum_
 
 - 값: `SCHEDULED(예약)`, `IN_PROGRESS(진행중)`, `COMPLETED(완료)`, `CANCELLED(취소)`
 
-## [ 계약 Aggregate ]
 
-## 계약 (Contract)
+## 프로젝트 매출 계획 (ProjectRevenuePlan)
 
-_Aggregate Root_
+_Entity_ (Project의 Child)
 
 ### 속성(필드)
 
 - `id`: `UUID` 고유 식별자 (AbstractEntity)
-- `projectId`: `UUID` 프로젝트 ID (not null)
-- `version`: `Integer` 계약 버전 (not null, default 1)
-- `contractType`: `ContractType` 계약 타입 (Enum, STRING, not null)
-- `contractDate`: `LocalDate` 계약일 (nullable)
-- `contractAmount`: `Money` 계약 금액 (not null)
-- `period`: `Period` 계약 기간 (not null)
+- `projectId`: `UUID` 프로젝트 ID (FK, not null)
+- `revenueMonth` : `String` 매출 인식 년월 (Format: YYYYMM, not null)
+- `type`: `RevenueType` 매출 구분 (Enum, STRING, not null)
+- `amount`: `Money` 매출 금액 (공급가액, not null)
+- `isIssued`: `Boolean` 세금계산서 발행 여부 (default false)
+- `description`: `String` 비고 (예: 1차 중도금)
 - 시스템 필드: BaseEntity의 감사/삭제 필드 일괄 적용
 
 ### 행위(메서드)
 
-- `static createInitial()`: 최초 계약을 생성
-- `static renew()`: 기존 계약을 갱신하여 새 버전 생성
-- `update()`: 계약 정보를 업데이트
+- `static plan()`: 특정 월의 매출 계획 수립
+- `issueInvoice()`: 세금계산서 발행 처리 (isIssued = true)
+- `cancelInvoice()`: 발행 취소
+- `adjustAmount()`: 금액 조정 (미발행 상태에서만 가능)
 
 ### 규칙/제약
 
-- 최초 계약의 버전은 1
-- 갱신 시 버전이 자동으로 증가
-- 계약 종료일은 시작일 이후여야 함
-- Soft Delete 지원
+- `revenueMonth`는 프로젝트 기간과 무관하게 설정 가능 (잔금 수금 지연 등 고려)
+- 이미 발행된 (isIssued=true) 계획은 금액을 수정할 수 없음
+- 동일 프로젝트 내 매출 계획의 총합은 프로젝트 계약금액과 일치해야 함
 
-### ContractType
+
+### RevenueType
 
 _enum_
 
-- 값: `INITIAL(최초)`, `AMENDMENT(변경)`
+- 값: `DOWN_PAYMENT(착수금)`, `INTERMEDIATE_PAYMENT(중도금)`, `BALANCE_PAYMENT(잔금)`, `MAINTENANCE(유지보수)`, `ETC(기타)`
+
 
 ## [ 프로젝트 투입 Aggregate ]
 
@@ -319,10 +322,10 @@ _Aggregate Root_
 ### 속성(필드)
 
 - `id`: `UUID` 고유 식별자 (AbstractEntity)
-- `contractId`: `UUID` 계약 ID (not null)
+- `projectId`: `UUID` 프로젝트 ID (not null)
 - `employeeId`: `UUID` 직원 ID (not null)
 - `assignmentRole`: `String` 투입 역할 (길이 최대 50, nullable)
-- `assignmentRate`: `Double` 투입률 (0.0 ~ 1.0, nullable)
+- `assignmentRate`: `Double` 투입률 (Man-Month 기준, 0.0 ~ 1.0, nullable)
 - `period`: `Period` 투입 기간 (not null)
 - 시스템 필드: BaseEntity의 감사/삭제 필드 일괄 적용
 
@@ -336,9 +339,71 @@ _Aggregate Root_
 
 - 직원 ID는 유효한 직원이어야 함
 - 계약 ID는 유효한 계약이어야 함
-- 투입률은 0.0 이상 1.0 이하여야 함
+- 투입률(assignmentRate)은 0.0 초과 1.0 이하여야 함
 - 투입 종료일은 시작일 이후여야 함
 - Soft Delete 지원
+- 원가 계산의 정확성을 위해 투입 기간은 '월(Month)' 단위로 분할 저장되는 것을 권장함
+예: 3월 15일 ~ 4월 20일 투입 시 -> [3월 0.5MM], [4월 0.6MM] 두 개의 레코드로 관리
+
+
+## [ 비용 정책 Aggregate ]
+직원 유형별 간접비/판관비 요율 관리
+
+## 직원 원가 정책 (EmployeeCostPolicy)
+
+_Aggregate Root_
+
+### 속성(필드)
+
+- `id`: `UUID` 고유 식별자 (AbstractEntity)
+- `applyYear`: `Integer` 적용 연도 (예: 2026, not null)
+- `employeeType`: `EmployeeType` 집직원 유형 (Enum, not null)
+- `directOverheadRate`: `Double` 제경비율 (0.0 ~ 1.0, not null, default 0.0)
+- `generalAdminRate`: `Double` 판관비율 (0.0 ~ 1.0, not null, default 0.0)
+- 시스템 필드: BaseEntity의 감사/삭제 필드 일괄 적용
+
+### 행위(메서드)
+
+- `static define()`: 특정 연도 및 유형의 정책 정의
+- `updateRates()`: 요율 수정
+
+### 규칙/제약
+
+- 동일한 `applyYear`와 `employeeType` 조합은 중복될 수 없음
+- 요율은 음수가 될 수 없음
+- 원가 계산 시 (1 + 제경비율 + 판관비율) 계수로 활용됨
+
+
+## [ 성과 분석 Aggregate ]
+배치 작업을 통해 집계된 월별 손익 데이터
+
+## 프로젝트 월별 집계 (ProjectMonthlySum)
+
+_Aggregate Root_
+
+### 속성(필드)
+
+- `id`: `UUID` 고유 식별자 (AbstractEntity)
+- `projectId`: `UUID` 프로젝트 ID (not null)
+- `targetMonth`: `String` 집계 대상 년월 (YYYYMM, not null)
+- `revenueAmount`: `Money` 확정 매출액 (세금계산서 기준)
+- `costAmount`: `Money` 확정 원가액 (계산식: (투입MM × 급여) + (투입MM × 제경비) + (투입MM × 판관비)) 
+- `profitAmount`: `Money` 확정 이익금 (매출(revenueAmount) - 원가(costAmount))
+- `isClosed`: `Boolean` 마감 여부 (true일 경우 배치 재계산 제외)
+- `closedAt`: `LocalDateTime` 마감 일시
+- 시스템 필드: BaseEntity의 감사/삭제 필드 일괄 적용
+
+### 행위(메서드)
+
+- `static create()`: 배치 실행 시 집계 정보
+- `close()`: 해당 월의 실적을 마감 처리 (수정 불가)
+
+### 규칙/제약
+
+- `projectId`와 `targetMonth`의 조합은 유일해야 함 (Unique Constraint)
+- `isClosed`가 `true`인 상태에서는 배치 작업에 의해 값이 변경되지 않아야 함
+- `profitAmount`는 `revenueAmount - costAmount`로 계산됨
+
 
 ## [ 계정 Aggregate ]
 


### PR DESCRIPTION
[프로젝트 Aggregate]
- 프로젝트 : 프로젝트 정의
- 프로젝트 매출 계획 : 착수금, 잔금 등 매출 계획 정의, 프로젝트와 1:M관계
- 매출 타입 : 매출 타입 정의 (착수금, 중도금, 잔금 등)
- (계약이 빠짐)

[프로젝트 투입 Aggregate]
- 프로젝트 투입 : 프로젝트 투입 M/M 정의, 프로젝트와 1:M관계

[비용 정책 Aggregate]
- 직원 원가 정책 : 제경비, 판관비 요율 정의

[성과 분석(집계) Aggregate]
- 프로젝트 월별 집계 : 배치로 집계되는 손익 데이터