### PR TITLE
[feature] 신규 계정 기본 그룹 자동 연결 및 auth/me 권한 응답 확장

### DIFF
--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/accountgroupassignment/AccountGroupAssignmentRepository.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/accountgroupassignment/AccountGroupAssignmentRepository.java
@@ -8,7 +8,8 @@ import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
 
 public interface AccountGroupAssignmentRepository
         extends Repository<AccountGroupAssignment, Long>,
-        kr.co.abacus.abms.application.permission.outbound.AccountGroupAssignmentRepository {
+        kr.co.abacus.abms.application.permission.outbound.AccountGroupAssignmentRepository,
+        kr.co.abacus.abms.application.auth.outbound.AccountPermissionGroupRepository {
 
     @Override
     AccountGroupAssignment save(AccountGroupAssignment assignment);
@@ -18,5 +19,8 @@ public interface AccountGroupAssignmentRepository
 
     @Override
     List<AccountGroupAssignment> findAllByAccountIdAndDeletedFalse(Long accountId);
+
+    @Override
+    boolean existsByAccountIdAndPermissionGroupIdAndDeletedFalse(Long accountId, Long permissionGroupId);
 
 }

--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/permissiongroup/PermissionGroupRepository.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/permissiongroup/PermissionGroupRepository.java
@@ -8,7 +8,8 @@ import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
 
 public interface PermissionGroupRepository
         extends Repository<PermissionGroup, Long>,
-        kr.co.abacus.abms.application.permission.outbound.PermissionGroupRepository {
+        kr.co.abacus.abms.application.permission.outbound.PermissionGroupRepository,
+        kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository {
 
     @Override
     PermissionGroup save(PermissionGroup permissionGroup);
@@ -18,5 +19,11 @@ public interface PermissionGroupRepository
 
     @Override
     List<PermissionGroup> findAllByIdInAndDeletedFalse(List<Long> ids);
+
+    @Override
+    java.util.Optional<PermissionGroup> findByGroupTypeAndNameAndDeletedFalse(
+            kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType groupType,
+            String name
+    );
 
 }

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthMeResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthMeResponse.java
@@ -1,14 +1,23 @@
 package kr.co.abacus.abms.adapter.api.auth.dto;
 
+import java.util.List;
+
 import kr.co.abacus.abms.application.auth.dto.AuthenticatedUserInfo;
 
 public record AuthMeResponse(
         String name,
-        String email
+        String email,
+        List<AuthPermissionResponse> permissions
 ) {
 
     public static AuthMeResponse from(AuthenticatedUserInfo userInfo) {
-        return new AuthMeResponse(userInfo.name(), userInfo.email());
+        return new AuthMeResponse(
+                userInfo.name(),
+                userInfo.email(),
+                userInfo.permissions().stream()
+                        .map(AuthPermissionResponse::from)
+                        .toList()
+        );
     }
 
 }

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthPermissionResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthPermissionResponse.java
@@ -1,0 +1,20 @@
+package kr.co.abacus.abms.adapter.api.auth.dto;
+
+import java.util.List;
+
+import kr.co.abacus.abms.application.permission.dto.GrantedPermissionDetail;
+import kr.co.abacus.abms.domain.grouppermissiongrant.PermissionScope;
+
+public record AuthPermissionResponse(
+        String code,
+        List<PermissionScope> scopes
+) {
+
+    public static AuthPermissionResponse from(GrantedPermissionDetail permissionDetail) {
+        return new AuthPermissionResponse(
+                permissionDetail.code(),
+                List.copyOf(permissionDetail.scopes())
+        );
+    }
+
+}

--- a/abms-api-boot/src/main/resources/data.sql
+++ b/abms-api-boot/src/main/resources/data.sql
@@ -592,3 +592,20 @@ INSERT INTO abms.tb_account(deleted, is_valid, login_fail_count, created_at, del
                             password_changed_at, updated_at, username, created_by, deleted_by, password, updated_by)
 VALUES (0, 1, 0, NOW(), NULL, 2, NOW(), NOW(), 'test2@iabacus.co.kr', 1, NULL,
         '{bcrypt}$2a$10$cYUYTpWDhwzsk.VEhowiduWUjqcfpA.sdL7BjDh3El/splYmywJMm', 1);
+
+
+-- ---------------------------------------------------------
+-- 14. 권한 그룹
+-- ---------------------------------------------------------
+INSERT INTO abms.tb_permission_group (id, name, description, group_type, created_at, updated_at, created_by, updated_by,
+                                      deleted, deleted_at, deleted_by)
+VALUES (1, '일반 그룹', '신규 계정에 기본 부여되는 시스템 권한 그룹이다.', 'SYSTEM', NOW(), NOW(), 1, 1, 0, NULL, NULL),
+       (2, '최고 관리자 그룹', '시스템 전체 권한을 관리하는 시스템 권한 그룹이다.', 'SYSTEM', NOW(), NOW(), 1, 1, 0, NULL, NULL);
+
+
+-- ---------------------------------------------------------
+-- 15. 계정-권한 그룹 매핑
+-- ---------------------------------------------------------
+INSERT INTO abms.tb_account_group_assignment (id, account_id, permission_group_id, created_at, updated_at, created_by,
+                                              updated_by, deleted, deleted_at, deleted_by)
+VALUES (1, 1, 2, NOW(), NOW(), 1, 1, 0, NULL, NULL);

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiDefaultPermissionGroupFailureTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiDefaultPermissionGroupFailureTest.java
@@ -1,0 +1,108 @@
+package kr.co.abacus.abms.adapter.api.auth;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.transaction.TestTransaction;
+
+import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
+import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
+import kr.co.abacus.abms.adapter.infrastructure.permissiongroup.PermissionGroupRepository;
+import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
+import kr.co.abacus.abms.domain.employee.Employee;
+import kr.co.abacus.abms.domain.employee.EmployeeAvatar;
+import kr.co.abacus.abms.domain.employee.EmployeeGrade;
+import kr.co.abacus.abms.domain.employee.EmployeePosition;
+import kr.co.abacus.abms.domain.employee.EmployeeType;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
+import kr.co.abacus.abms.domain.shared.Email;
+import kr.co.abacus.abms.support.ApiIntegrationTestBase;
+
+@DisplayName("기본 권한 그룹 미구성 시 인증 API (AuthApi)")
+class AuthApiDefaultPermissionGroupFailureTest extends ApiIntegrationTestBase {
+
+    @Autowired
+    private EmployeeRepository employeeRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    @Autowired
+    private RegistrationTokenRepository registrationTokenRepository;
+
+    @MockitoSpyBean
+    private PermissionGroupRepository permissionGroupRepository;
+
+    @Test
+    @DisplayName("기본 권한 그룹이 없으면 회원가입 확정은 500을 반환하고 계정 생성을 롤백한다")
+    void should_rollbackAccountCreation_whenDefaultPermissionGroupIsMissing() throws Exception {
+        String email = "default-group-failure@iabacus.co.kr";
+        String password = "NewPassword123!";
+
+        given(permissionGroupRepository.findByGroupTypeAndNameAndDeletedFalse(
+                PermissionGroupType.SYSTEM,
+                "일반 그룹"
+        )).willReturn(Optional.empty());
+
+        employeeRepository.save(createEmployee(email, "기본그룹미설정직원"));
+        flushAndClear();
+
+        mockMvc.perform(post("/api/auth/registration-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("email", email))))
+                .andExpect(status().isOk());
+
+        String token = registrationTokenRepository.findFirstByEmailOrderByCreatedAtDesc(new Email(email))
+                .orElseThrow()
+                .getToken();
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+        TestTransaction.start();
+
+        mockMvc.perform(post("/api/auth/registration-confirmations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "token", token,
+                                "password", password
+                        ))))
+                .andExpect(status().isInternalServerError());
+
+        TestTransaction.end();
+        TestTransaction.start();
+
+        assertThat(accountRepository.findByUsername(new Email(email))).isEmpty();
+        assertThat(registrationTokenRepository.findByToken(token)).isPresent();
+    }
+
+    private String toJson(Object value) throws Exception {
+        return objectMapper.writeValueAsString(value);
+    }
+
+    private Employee createEmployee(String email, String name) {
+        return Employee.create(
+                1L,
+                name,
+                email,
+                LocalDate.of(2025, 1, 2),
+                LocalDate.of(1995, 6, 10),
+                EmployeePosition.ASSOCIATE,
+                EmployeeType.FULL_TIME,
+                EmployeeGrade.JUNIOR,
+                EmployeeAvatar.SKY_GLOW,
+                null
+        );
+    }
+
+}

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,15 +21,26 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MvcResult;
 
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
+import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
+import kr.co.abacus.abms.application.permission.outbound.AccountGroupAssignmentRepository;
+import kr.co.abacus.abms.application.permission.outbound.GroupPermissionGrantRepository;
+import kr.co.abacus.abms.application.permission.outbound.PermissionGroupRepository;
+import kr.co.abacus.abms.application.permission.outbound.PermissionRepository;
 import kr.co.abacus.abms.domain.account.Account;
+import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
 import kr.co.abacus.abms.domain.auth.RegistrationToken;
 import kr.co.abacus.abms.domain.employee.Employee;
 import kr.co.abacus.abms.domain.employee.EmployeeAvatar;
 import kr.co.abacus.abms.domain.employee.EmployeeGrade;
 import kr.co.abacus.abms.domain.employee.EmployeePosition;
 import kr.co.abacus.abms.domain.employee.EmployeeType;
+import kr.co.abacus.abms.domain.grouppermissiongrant.GroupPermissionGrant;
+import kr.co.abacus.abms.domain.grouppermissiongrant.PermissionScope;
+import kr.co.abacus.abms.domain.permission.Permission;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
 import kr.co.abacus.abms.domain.shared.Email;
 import kr.co.abacus.abms.support.ApiIntegrationTestBase;
 
@@ -49,6 +61,21 @@ class AuthApiTest extends ApiIntegrationTestBase {
 
     @Autowired
     private RegistrationTokenRepository registrationTokenRepository;
+
+    @Autowired
+    private DefaultPermissionGroupRepository defaultPermissionGroupRepository;
+
+    @Autowired
+    private AccountGroupAssignmentRepository accountGroupAssignmentRepository;
+
+    @Autowired
+    private PermissionGroupRepository permissionGroupRepository;
+
+    @Autowired
+    private GroupPermissionGrantRepository groupPermissionGrantRepository;
+
+    @Autowired
+    private PermissionRepository permissionRepository;
 
     @BeforeEach
     void setUpAccount() {
@@ -101,7 +128,75 @@ class AuthApiTest extends ApiIntegrationTestBase {
         mockMvc.perform(get("/api/auth/me").session(session))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(USERNAME))
-                .andExpect(jsonPath("$.name").value("인증사용자"));
+                .andExpect(jsonPath("$.name").value("인증사용자"))
+                .andExpect(jsonPath("$.permissions").isArray())
+                .andExpect(jsonPath("$.permissions").isEmpty());
+    }
+
+    @Test
+    @DisplayName("로그인 후 현재 사용자 권한 정보를 정렬된 형식으로 조회할 수 있다")
+    void should_getCurrentUserPermissions_whenAuthenticated() throws Exception {
+        Account account = accountRepository.findByUsername(new Email(USERNAME)).orElseThrow();
+        Permission employeeReadPermission = permissionRepository.save(Permission.create(
+                "employee.read",
+                "직원 조회",
+                "직원 조회 권한"
+        ));
+        Permission employeeManagePermission = permissionRepository.save(Permission.create(
+                "employee.manage",
+                "직원 관리",
+                "직원 관리 권한"
+        ));
+
+        PermissionGroup readPermissionGroup = permissionGroupRepository.save(PermissionGroup.create(
+                "직원 조회 그룹",
+                "직원 조회 권한 그룹",
+                PermissionGroupType.CUSTOM
+        ));
+        PermissionGroup managePermissionGroup = permissionGroupRepository.save(PermissionGroup.create(
+                "직원 관리 그룹",
+                "직원 관리 권한 그룹",
+                PermissionGroupType.CUSTOM
+        ));
+
+        accountGroupAssignmentRepository.saveAll(List.of(
+                AccountGroupAssignment.create(account.getIdOrThrow(), readPermissionGroup.getIdOrThrow()),
+                AccountGroupAssignment.create(account.getIdOrThrow(), managePermissionGroup.getIdOrThrow())
+        ));
+        groupPermissionGrantRepository.saveAll(List.of(
+                GroupPermissionGrant.create(readPermissionGroup.getIdOrThrow(),
+                        employeeReadPermission.getIdOrThrow(),
+                        PermissionScope.SELF),
+                GroupPermissionGrant.create(managePermissionGroup.getIdOrThrow(),
+                        employeeReadPermission.getIdOrThrow(),
+                        PermissionScope.OWN_DEPARTMENT),
+                GroupPermissionGrant.create(managePermissionGroup.getIdOrThrow(),
+                        employeeManagePermission.getIdOrThrow(),
+                        PermissionScope.ALL)
+        ));
+        flushAndClear();
+
+        MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "username", USERNAME,
+                                "password", PASSWORD
+                        ))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MockHttpSession session = (MockHttpSession) loginResult.getRequest().getSession(false);
+        assertThat(session).isNotNull();
+
+        mockMvc.perform(get("/api/auth/me").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value(USERNAME))
+                .andExpect(jsonPath("$.name").value("인증사용자"))
+                .andExpect(jsonPath("$.permissions[0].code").value("employee.manage"))
+                .andExpect(jsonPath("$.permissions[0].scopes[0]").value("ALL"))
+                .andExpect(jsonPath("$.permissions[1].code").value("employee.read"))
+                .andExpect(jsonPath("$.permissions[1].scopes[0]").value("OWN_DEPARTMENT"))
+                .andExpect(jsonPath("$.permissions[1].scopes[1]").value("SELF"));
     }
 
     @Test
@@ -266,8 +361,19 @@ class AuthApiTest extends ApiIntegrationTestBase {
                 .andExpect(status().isOk());
         flushAndClear();
 
+        // 회원 가입 시 권한 그룹이 일반 그룹으로 기본 지정된다.
         Account account = accountRepository.findByUsername(new Email(email)).orElseThrow();
+        PermissionGroup defaultPermissionGroup = defaultPermissionGroupRepository.findByGroupTypeAndNameAndDeletedFalse(
+                PermissionGroupType.SYSTEM,
+                "일반 그룹"
+        ).orElseThrow();
+        List<AccountGroupAssignment> assignments =
+                accountGroupAssignmentRepository.findAllByAccountIdAndDeletedFalse(account.getIdOrThrow());
+
         assertThat(passwordEncoder.matches(newPassword, account.getPassword())).isTrue();
+        assertThat(assignments)
+                .extracting(AccountGroupAssignment::getPermissionGroupId)
+                .containsExactly(defaultPermissionGroup.getIdOrThrow());
         assertThat(registrationTokenRepository.findByToken(registrationToken.getToken())).isEmpty();
     }
 

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupInitializerTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupInitializerTest.java
@@ -1,0 +1,54 @@
+package kr.co.abacus.abms.application.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
+import kr.co.abacus.abms.support.IntegrationTestBase;
+
+@DisplayName("기본 권한 그룹 초기화")
+class DefaultPermissionGroupInitializerTest extends IntegrationTestBase {
+
+    @Autowired
+    private DefaultPermissionGroupInitializer defaultPermissionGroupInitializer;
+
+    @Test
+    @DisplayName("애플리케이션 시작 시 기본 시스템 권한 그룹을 생성한다")
+    void should_initializeDefaultPermissionGroup_onApplicationReady() {
+        List<PermissionGroup> defaultPermissionGroups = findDefaultPermissionGroups();
+
+        assertThat(defaultPermissionGroups).hasSize(1);
+        assertThat(defaultPermissionGroups.getFirst().getGroupType()).isEqualTo(PermissionGroupType.SYSTEM);
+        assertThat(defaultPermissionGroups.getFirst().getDescription()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("기본 권한 그룹 초기화는 중복 생성 없이 한 번만 수행된다")
+    void should_notCreateDuplicateDefaultPermissionGroup_whenInitializerRunsAgain() {
+        defaultPermissionGroupInitializer.initializeDefaultPermissionGroup();
+        flushAndClear();
+
+        assertThat(findDefaultPermissionGroups()).hasSize(1);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<PermissionGroup> findDefaultPermissionGroups() {
+        return entityManager.createQuery("""
+                        select permissionGroup
+                        from PermissionGroup permissionGroup
+                        where permissionGroup.groupType = :groupType
+                          and permissionGroup.name = :name
+                          and permissionGroup.deleted = false
+                        """)
+                .setParameter("groupType", PermissionGroupType.SYSTEM)
+                .setParameter("name", DefaultPermissionGroupInitializer.DEFAULT_PERMISSION_GROUP_NAME)
+                .getResultList();
+    }
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthCommandService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthCommandService.java
@@ -15,12 +15,15 @@ import kr.co.abacus.abms.application.auth.dto.LoginCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationConfirmCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationRequestCommand;
 import kr.co.abacus.abms.application.auth.inbound.AuthManager;
+import kr.co.abacus.abms.application.auth.outbound.AccountPermissionGroupRepository;
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.auth.outbound.CredentialAuthenticator;
+import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationLinkSender;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
 import kr.co.abacus.abms.domain.account.Account;
+import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
 import kr.co.abacus.abms.domain.account.AccountAlreadyExistsException;
 import kr.co.abacus.abms.domain.account.AccountNotFoundException;
 import kr.co.abacus.abms.domain.account.InvalidCurrentPasswordException;
@@ -29,6 +32,8 @@ import kr.co.abacus.abms.domain.auth.InvalidRegistrationTokenException;
 import kr.co.abacus.abms.domain.auth.RegistrationToken;
 import kr.co.abacus.abms.domain.employee.Employee;
 import kr.co.abacus.abms.domain.employee.EmployeeNotFoundException;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
 import kr.co.abacus.abms.domain.shared.Email;
 
 @RequiredArgsConstructor
@@ -42,6 +47,8 @@ public class AuthCommandService implements AuthManager {
     private final RegistrationTokenRepository registrationTokenRepository;
     private final RegistrationLinkSender registrationLinkSender;
     private final PasswordEncoder passwordEncoder;
+    private final DefaultPermissionGroupRepository defaultPermissionGroupRepository;
+    private final AccountPermissionGroupRepository accountPermissionGroupRepository;
 
     @Override
     public void requestRegistration(RegistrationRequestCommand command) {
@@ -80,11 +87,12 @@ public class AuthCommandService implements AuthManager {
         validateAlreadyRegistered(email);
         String encodedPassword = Objects.requireNonNull(passwordEncoder.encode(command.password()));
 
-        accountRepository.save(Account.create(
+        Account account = accountRepository.save(Account.create(
                 registrationToken.getEmployeeId(),
                 email.address(),
                 encodedPassword
         ));
+        assignDefaultPermissionGroup(account);
         registrationTokenRepository.delete(registrationToken);
     }
 
@@ -114,6 +122,27 @@ public class AuthCommandService implements AuthManager {
         if (accountRepository.findByUsername(email).isPresent()) {
             throw new AccountAlreadyExistsException("이미 가입된 계정입니다: " + email.address());
         }
+    }
+
+    private void assignDefaultPermissionGroup(Account account) {
+        PermissionGroup defaultPermissionGroup = defaultPermissionGroupRepository.findByGroupTypeAndNameAndDeletedFalse(
+                PermissionGroupType.SYSTEM,
+                DefaultPermissionGroupInitializer.DEFAULT_PERMISSION_GROUP_NAME
+        ).orElseThrow(() -> new DefaultPermissionGroupNotConfiguredException(
+                "기본 권한 그룹이 설정되지 않았습니다: " + DefaultPermissionGroupInitializer.DEFAULT_PERMISSION_GROUP_NAME
+        ));
+
+        if (accountPermissionGroupRepository.existsByAccountIdAndPermissionGroupIdAndDeletedFalse(
+                account.getIdOrThrow(),
+                defaultPermissionGroup.getIdOrThrow()
+        )) {
+            return;
+        }
+
+        accountPermissionGroupRepository.save(AccountGroupAssignment.create(
+                account.getIdOrThrow(),
+                defaultPermissionGroup.getIdOrThrow()
+        ));
     }
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthQueryService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthQueryService.java
@@ -9,6 +9,7 @@ import kr.co.abacus.abms.application.auth.dto.AuthenticatedUserInfo;
 import kr.co.abacus.abms.application.auth.inbound.AuthFinder;
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
+import kr.co.abacus.abms.application.permission.inbound.PermissionFinder;
 import kr.co.abacus.abms.domain.account.Account;
 import kr.co.abacus.abms.domain.account.AccountNotFoundException;
 import kr.co.abacus.abms.domain.employee.Employee;
@@ -21,6 +22,7 @@ public class AuthQueryService implements AuthFinder {
 
     private final AccountRepository accountRepository;
     private final EmployeeRepository employeeRepository;
+    private final PermissionFinder permissionFinder;
 
     @Override
     public AuthenticatedUserInfo getCurrentUser(String username) {
@@ -43,7 +45,8 @@ public class AuthQueryService implements AuthFinder {
         return employeeRepository.findById(account.getEmployeeId())
                 .map(employee -> new AuthenticatedUserInfo(
                         employee.getName(),
-                        employee.getEmail().address()
+                        employee.getEmail().address(),
+                        permissionFinder.findPermissions(account.getIdOrThrow()).permissions()
                 ))
                 .orElseGet(() -> fallbackUserInfo(account.getUsername().address()));
     }
@@ -51,7 +54,7 @@ public class AuthQueryService implements AuthFinder {
     private AuthenticatedUserInfo fallbackUserInfo(String email) {
         String localPart = email.split("@")[0];
         String normalizedName = localPart.isBlank() ? email : localPart;
-        return new AuthenticatedUserInfo(normalizedName, email);
+        return new AuthenticatedUserInfo(normalizedName, email, java.util.List.of());
     }
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupInitializer.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupInitializer.java
@@ -1,0 +1,36 @@
+package kr.co.abacus.abms.application.auth;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
+
+@RequiredArgsConstructor
+@Component
+public class DefaultPermissionGroupInitializer {
+
+    public static final String DEFAULT_PERMISSION_GROUP_NAME = "일반 그룹";
+    private static final String DEFAULT_PERMISSION_GROUP_DESCRIPTION = "신규 계정에 기본 부여되는 시스템 권한 그룹이다.";
+
+    private final DefaultPermissionGroupRepository defaultPermissionGroupRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void initializeDefaultPermissionGroup() {
+        defaultPermissionGroupRepository.findByGroupTypeAndNameAndDeletedFalse(
+                PermissionGroupType.SYSTEM,
+                DEFAULT_PERMISSION_GROUP_NAME
+        ).orElseGet(() -> defaultPermissionGroupRepository.save(PermissionGroup.create(
+                DEFAULT_PERMISSION_GROUP_NAME,
+                DEFAULT_PERMISSION_GROUP_DESCRIPTION,
+                PermissionGroupType.SYSTEM
+        )));
+    }
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupNotConfiguredException.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/DefaultPermissionGroupNotConfiguredException.java
@@ -1,0 +1,9 @@
+package kr.co.abacus.abms.application.auth;
+
+public class DefaultPermissionGroupNotConfiguredException extends RuntimeException {
+
+    public DefaultPermissionGroupNotConfiguredException(String message) {
+        super(message);
+    }
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/AuthenticatedUserInfo.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/AuthenticatedUserInfo.java
@@ -1,8 +1,13 @@
 package kr.co.abacus.abms.application.auth.dto;
 
+import java.util.List;
+
+import kr.co.abacus.abms.application.permission.dto.GrantedPermissionDetail;
+
 public record AuthenticatedUserInfo(
         String name,
-        String email
+        String email,
+        List<GrantedPermissionDetail> permissions
 ) {
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/AccountPermissionGroupRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/AccountPermissionGroupRepository.java
@@ -1,0 +1,11 @@
+package kr.co.abacus.abms.application.auth.outbound;
+
+import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
+
+public interface AccountPermissionGroupRepository {
+
+    AccountGroupAssignment save(AccountGroupAssignment assignment);
+
+    boolean existsByAccountIdAndPermissionGroupIdAndDeletedFalse(Long accountId, Long permissionGroupId);
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/DefaultPermissionGroupRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/DefaultPermissionGroupRepository.java
@@ -1,0 +1,14 @@
+package kr.co.abacus.abms.application.auth.outbound;
+
+import java.util.Optional;
+
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroup;
+import kr.co.abacus.abms.domain.permissiongroup.PermissionGroupType;
+
+public interface DefaultPermissionGroupRepository {
+
+    PermissionGroup save(PermissionGroup permissionGroup);
+
+    Optional<PermissionGroup> findByGroupTypeAndNameAndDeletedFalse(PermissionGroupType groupType, String name);
+
+}

--- a/abms-batch-boot/src/main/resources/data.sql
+++ b/abms-batch-boot/src/main/resources/data.sql
@@ -395,3 +395,33 @@ INSERT INTO abms.tb_employee_monthly_cost (deleted,monthly_salary,overhead_cost,
 	 (0,3750000.00,375000.00,187500.00,4312500.00,'202602',NOW(),NULL,47,NOW(),1,NULL,1),
 	 (0,3416667.00,341667.00,170833.00,3929167.00,'202602',NOW(),NULL,48,NOW(),1,NULL,1),
 	 (0,4000000.00,400000.00,200000.00,4600000.00,'202602',NOW(),NULL,49,NOW(),1,NULL,1);
+
+
+-- ---------------------------------------------------------
+-- 13. 계정
+-- ---------------------------------------------------------
+INSERT INTO abms.tb_account(deleted, is_valid, login_fail_count, created_at, deleted_at, employee_id,
+                            password_changed_at, updated_at, username, created_by, deleted_by, password, updated_by)
+VALUES (0, 1, 0, NOW(), NULL, 1, NOW(), NOW(), 'test@iabacus.co.kr', 1, NULL,
+        '{bcrypt}$2a$10$cYUYTpWDhwzsk.VEhowiduWUjqcfpA.sdL7BjDh3El/splYmywJMm', 1);
+INSERT INTO abms.tb_account(deleted, is_valid, login_fail_count, created_at, deleted_at, employee_id,
+                            password_changed_at, updated_at, username, created_by, deleted_by, password, updated_by)
+VALUES (0, 1, 0, NOW(), NULL, 2, NOW(), NOW(), 'test2@iabacus.co.kr', 1, NULL,
+        '{bcrypt}$2a$10$cYUYTpWDhwzsk.VEhowiduWUjqcfpA.sdL7BjDh3El/splYmywJMm', 1);
+
+
+-- ---------------------------------------------------------
+-- 14. 권한 그룹
+-- ---------------------------------------------------------
+INSERT INTO abms.tb_permission_group (id, name, description, group_type, created_at, updated_at, created_by, updated_by,
+                                      deleted, deleted_at, deleted_by)
+VALUES (1, '일반 그룹', '신규 계정에 기본 부여되는 시스템 권한 그룹이다.', 'SYSTEM', NOW(), NOW(), 1, 1, 0, NULL, NULL),
+       (2, '최고 관리자 그룹', '시스템 전체 권한을 관리하는 시스템 권한 그룹이다.', 'SYSTEM', NOW(), NOW(), 1, 1, 0, NULL, NULL);
+
+
+-- ---------------------------------------------------------
+-- 15. 계정-권한 그룹 매핑
+-- ---------------------------------------------------------
+INSERT INTO abms.tb_account_group_assignment (id, account_id, permission_group_id, created_at, updated_at, created_by,
+                                              updated_by, deleted, deleted_at, deleted_by)
+VALUES (1, 1, 2, NOW(), NOW(), 1, 1, 0, NULL, NULL);


### PR DESCRIPTION
## 변경 요약
- 회원가입 확정 시 기본 시스템 권한 그룹 `일반 그룹`을 자동 연결하도록 추가
- `/api/auth/me` 응답에 현재 사용자의 권한 코드와 범위 목록을 포함하도록 확장
- API/배치 `data.sql`에 `일반 그룹`, `최고 관리자 그룹`, 1번 계정 최고 관리자 그룹 매핑 시드 추가

## 관련 이슈 (필수)
- Closes #50
- Refs #43

## 핵심 검증 (필수)
- [x] 로컬에서 핵심 시나리오를 검증했다.
- 검증 내용 요약:
  - `./gradlew :abms-api-boot:test --tests 'kr.co.abacus.abms.application.permission.inbound.PermissionFinderTest' --tests 'kr.co.abacus.abms.application.permission.outbound.PermissionRepositoryTest' --tests 'kr.co.abacus.abms.adapter.api.auth.AuthApiTest' --tests 'kr.co.abacus.abms.adapter.api.auth.AuthApiMailFailureTest' --tests 'kr.co.abacus.abms.adapter.api.auth.AuthApiDefaultPermissionGroupFailureTest' --tests 'kr.co.abacus.abms.application.auth.DefaultPermissionGroupInitializerTest'`
  - `./gradlew :abms-api-boot:test --tests 'kr.co.abacus.abms.AbmsApplicationTests'`

## 증빙 자료 (조건부 필수)
- [x] UI 변경 없음
- [ ] UI 변경 있음: Before/After 캡처 첨부
- [ ] 동작 흐름 확인 필요: GIF/MP4 첨부
- 첨부 링크/설명:
  - 없음

## 영향도 (필수)
- API 변경: [x] 있음 [ ] 없음
- DB 스키마/데이터 마이그레이션: [ ] 있음 [x] 없음
- ENV 변수 추가/변경: [ ] 있음 [x] 없음

## 리뷰/머지 체크
- [ ] 팀원 1명 승인 완료
- [ ] CI 체크 통과

## Hotfix 예외
- [ ] 이 PR은 `hotfix/*` 이다.
- [ ] 사후 리뷰 이슈를 생성했고 24시간 내 리뷰한다.
