### PR TITLE
refactor: 프로젝트 조회·수정 경계와 날짜 조건 의미 정비

### DIFF
--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/project/PoiProjectExcelImporter.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/project/PoiProjectExcelImporter.java
@@ -15,8 +15,8 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Component;
 
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
 import kr.co.abacus.abms.application.project.outbound.ProjectExcelImporter;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectExcelException;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 
@@ -35,14 +35,14 @@ public class PoiProjectExcelImporter implements ProjectExcelImporter {
     );
 
     @Override
-    public List<ProjectCreateRequest> importProjects(InputStream inputStream, Function<String, Long> partyLookup) {
+    public List<ProjectCreateCommand> importProjects(InputStream inputStream, Function<String, Long> partyLookup) {
         try (Workbook workbook = new XSSFWorkbook(inputStream)) {
             Sheet sheet = workbook.getSheetAt(0);
             if (sheet == null || sheet.getPhysicalNumberOfRows() < 2) {
                 throw new ProjectExcelException("유효한 데이터가 포함된 시트를 찾을 수 없습니다.");
             }
 
-            List<ProjectCreateRequest> requests = new ArrayList<>();
+            List<ProjectCreateCommand> requests = new ArrayList<>();
             for (int rowIndex = 1; rowIndex <= sheet.getLastRowNum(); rowIndex++) {
                 Row row = sheet.getRow(rowIndex);
                 if (row == null || isRowEmpty(row)) {
@@ -58,7 +58,7 @@ public class PoiProjectExcelImporter implements ProjectExcelImporter {
         }
     }
 
-    private ProjectCreateRequest toCreateRequest(Row row, Function<String, Long> partyLookup) {
+    private ProjectCreateCommand toCreateRequest(Row row, Function<String, Long> partyLookup) {
         String partyName = getCellValue(row, 0);
         String leadDepartmentName = getCellValue(row, 1);
         String code = getCellValue(row, 2);
@@ -74,7 +74,7 @@ public class PoiProjectExcelImporter implements ProjectExcelImporter {
             throw new IllegalArgumentException("존재하지 않는 협력사입니다: " + partyName);
         }
 
-        return new ProjectCreateRequest(
+        return new ProjectCreateCommand(
                 partyId,
                 Long.parseLong(leadDepartmentName), // 임시
                 code,

--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/project/ProjectRepositoryImpl.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/project/ProjectRepositoryImpl.java
@@ -1,9 +1,9 @@
 package kr.co.abacus.abms.adapter.infrastructure.project;
 
+import static kr.co.abacus.abms.domain.party.QParty.*;
 import static kr.co.abacus.abms.domain.project.QProject.*;
 import static org.springframework.util.StringUtils.*;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,8 +20,6 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -49,6 +47,7 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
                 .select(Projections.constructor(ProjectSummary.class,
                         project.id,
                         project.partyId,
+                        party.name,
                         project.code,
                         project.name,
                         project.description,
@@ -57,12 +56,12 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
                         project.period.startDate,
                         project.period.endDate))
                 .from(project)
+                .join(party).on(project.partyId.eq(party.id))
                 .where(
                         containsNameOrCode(condition.name()),
                         inStatuses(condition.statuses()),
                         inPartyIds(condition.partyIds()),
-                        startDateFrom(condition.startDate()),
-                        startDateTo(condition.endDate()),
+                        overlapsPeriod(condition.periodStart(), condition.periodEnd()),
                         project.deleted.isFalse())
                 .orderBy(orderSpecifiers)
                 .offset(pageable.getOffset())
@@ -72,12 +71,12 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
         JPAQuery<Long> countQuery = queryFactory
                 .select(project.count())
                 .from(project)
+                .join(party).on(project.partyId.eq(party.id))
                 .where(
                         containsNameOrCode(condition.name()),
                         inStatuses(condition.statuses()),
                         inPartyIds(condition.partyIds()),
-                        startDateFrom(condition.startDate()),
-                        startDateTo(condition.endDate()),
+                        overlapsPeriod(condition.periodStart(), condition.periodEnd()),
                         project.deleted.isFalse());
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
@@ -102,8 +101,7 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
                         containsNameOrCode(condition.name()),
                         inStatuses(condition.statuses()),
                         inPartyIds(condition.partyIds()),
-                        startDateFrom(condition.startDate()),
-                        startDateTo(condition.endDate()),
+                        overlapsPeriod(condition.periodStart(), condition.periodEnd()),
                         project.deleted.isFalse())
                 .orderBy(defaultSort())
                 .fetch();
@@ -131,12 +129,18 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
         return project.partyId.in(partyIds);
     }
 
-    private @Nullable BooleanExpression startDateFrom(@Nullable LocalDate startDate) {
-        return startDate != null ? project.period.startDate.goe(startDate) : null;
-    }
-
-    private @Nullable BooleanExpression startDateTo(@Nullable LocalDate endDate) {
-        return endDate != null ? project.period.startDate.loe(endDate) : null;
+    private @Nullable BooleanExpression overlapsPeriod(@Nullable LocalDate periodStart, @Nullable LocalDate periodEnd) {
+        if (periodStart == null && periodEnd == null) {
+            return null;
+        }
+        if (periodStart != null && periodEnd != null) {
+            return project.period.startDate.loe(periodEnd)
+                    .and(project.period.endDate.isNull().or(project.period.endDate.goe(periodStart)));
+        }
+        if (periodStart != null) {
+            return project.period.endDate.isNull().or(project.period.endDate.goe(periodStart));
+        }
+        return project.period.startDate.loe(periodEnd);
     }
 
     private OrderSpecifier<?>[] resolveSort(Pageable pageable) {
@@ -158,8 +162,8 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
             case "name" -> new OrderSpecifier<>(direction, project.name);
             case "status" -> new OrderSpecifier<>(direction, project.status);
             case "contractAmount" -> new OrderSpecifier<>(direction, project.contractAmount.amount);
-            case "startDate" -> new OrderSpecifier<>(direction, project.period.startDate);
-            case "endDate" -> new OrderSpecifier<>(direction, project.period.endDate);
+            case "periodStart" -> new OrderSpecifier<>(direction, project.period.startDate);
+            case "periodEnd" -> new OrderSpecifier<>(direction, project.period.endDate);
             case "createdAt" -> new OrderSpecifier<>(direction, project.createdAt);
             default -> defaultSort();
         };
@@ -177,8 +181,7 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
                         containsNameOrCode(condition.name()),
                         inStatuses(condition.statuses()),
                         inPartyIds(condition.partyIds()),
-                        startDateFrom(condition.startDate()),
-                        startDateTo(condition.endDate()),
+                        overlapsPeriod(condition.periodStart(), condition.periodEnd()),
                         extraCondition,
                         project.deleted.isFalse())
                 .fetchOne();
@@ -193,8 +196,7 @@ public class ProjectRepositoryImpl implements CustomProjectRepository {
                         containsNameOrCode(condition.name()),
                         inStatuses(condition.statuses()),
                         inPartyIds(condition.partyIds()),
-                        startDateFrom(condition.startDate()),
-                        startDateTo(condition.endDate()),
+                        overlapsPeriod(condition.periodStart(), condition.periodEnd()),
                         project.deleted.isFalse())
                 .fetchOne();
         return value != null ? value : 0L;

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/common/InitData.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/common/InitData.java
@@ -23,7 +23,6 @@ import kr.co.abacus.abms.domain.payroll.Payroll;
 import kr.co.abacus.abms.domain.positionhistory.PositionHistory;
 import kr.co.abacus.abms.domain.positionhistory.PositionHistoryCreateRequest;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlan;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlanCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
@@ -624,7 +623,7 @@ public class InitData {
         // 프로젝트 (프로젝트, 매출 일정, 인력 투입) 구성
         // ---------------------------------------------------------
         Project aiProject = projectRepository.save(
-            Project.create(new ProjectCreateRequest(
+            Project.create(
                 partyNaverCloud.getIdOrThrow(),
                 22L, // PM ID (임의)
                 "PROJ-2026-AI",
@@ -634,7 +633,7 @@ public class InitData {
                 1000000000L, // 총 계약금 10억
                 LocalDate.of(2026, 1, 1),
                 LocalDate.of(2026, 6, 30)
-            ))
+            )
         );
 
         ProjectRevenuePlan aiPlanJan = projectRevenuePlanRepository.save(

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/ProjectApi.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/ProjectApi.java
@@ -4,9 +4,14 @@ import jakarta.validation.Valid;
 
 import kr.co.abacus.abms.adapter.api.common.FilenameBuilder;
 import kr.co.abacus.abms.adapter.api.common.PageResponse;
-import kr.co.abacus.abms.adapter.api.project.dto.*;
-import kr.co.abacus.abms.application.department.DepartmentQueryService;
-import kr.co.abacus.abms.application.party.PartyQueryService;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectCreateApiRequest;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectCreateResponse;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectDetailResponse;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectExcelUploadResponse;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectResponse;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectStatusResponse;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectUpdateApiRequest;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectUpdateResponse;
 import kr.co.abacus.abms.application.project.ProjectExcelService;
 import kr.co.abacus.abms.application.project.ProjectQueryService;
 import kr.co.abacus.abms.application.project.dto.ProjectDetail;
@@ -16,7 +21,6 @@ import kr.co.abacus.abms.application.project.dto.ProjectSearchCondition;
 import kr.co.abacus.abms.application.project.dto.ProjectSummary;
 import kr.co.abacus.abms.application.project.inbound.ProjectFinder;
 import kr.co.abacus.abms.application.project.inbound.ProjectManager;
-import kr.co.abacus.abms.domain.project.Project;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -42,26 +46,20 @@ public class ProjectApi {
 
     private final ProjectManager projectManager;
     private final ProjectFinder projectFinder;
-    private final PartyQueryService partyQueryService;
     private final ProjectQueryService projectQueryService;
     private final ProjectExcelService projectExcelService;
 
     @PostMapping("/api/projects")
-    public ProjectResponse create(@RequestBody ProjectCreateApiRequest request) {
-        Project project = projectManager.create(request.toDomainRequest());
-        String partyName = partyQueryService.getPartyName(project.getPartyId());
-
-        return ProjectResponse.from(project, partyName);
+    public ProjectCreateResponse create(@RequestBody ProjectCreateApiRequest request) {
+        Long projectId = projectManager.create(request.toCommand());
+        return ProjectCreateResponse.of(projectId);
     }
 
     @GetMapping("/api/projects")
     public PageResponse<ProjectResponse> search(@Valid ProjectSearchCondition condition, Pageable pageable) {
         Page<ProjectSummary> projects = projectFinder.search(condition, pageable);
 
-        return PageResponse.of(projects.map(project -> {
-            String partyName = partyQueryService.getPartyName(project.partyId());
-            return ProjectResponse.from(project, partyName);
-        }));
+        return PageResponse.of(projects.map(ProjectResponse::from));
     }
 
     @GetMapping("/api/projects/summary")
@@ -76,27 +74,21 @@ public class ProjectApi {
     }
 
     @PutMapping("/api/projects/{id}")
-    public ProjectResponse update(@PathVariable Long id, @RequestBody ProjectUpdateApiRequest request) {
-        Project project = projectManager.update(id, request.toDomainRequest());
-        String partyName = partyQueryService.getPartyName(project.getPartyId());
-
-        return ProjectResponse.from(project, partyName);
+    public ProjectUpdateResponse update(@PathVariable Long id, @RequestBody ProjectUpdateApiRequest request) {
+        Long projectId = projectManager.update(id, request.toCommand());
+        return ProjectUpdateResponse.of(projectId);
     }
 
     @PatchMapping("/api/projects/{id}/complete")
-    public ProjectResponse complete(@PathVariable Long id) {
-        Project project = projectManager.complete(id);
-        String partyName = partyQueryService.getPartyName(project.getPartyId());
-
-        return ProjectResponse.from(project, partyName);
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void complete(@PathVariable Long id) {
+        projectManager.complete(id);
     }
 
     @PatchMapping("/api/projects/{id}/cancel")
-    public ProjectResponse cancel(@PathVariable Long id) {
-        Project project = projectManager.cancel(id);
-        String partyName = partyQueryService.getPartyName(project.getPartyId());
-
-        return ProjectResponse.from(project, partyName);
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void cancel(@PathVariable Long id) {
+        projectManager.cancel(id);
     }
 
     @DeleteMapping("/api/projects/{id}")

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectCreateApiRequest.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectCreateApiRequest.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 import org.jspecify.annotations.Nullable;
 
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 
 public record ProjectCreateApiRequest(
@@ -16,10 +16,10 @@ public record ProjectCreateApiRequest(
         ProjectStatus status,
         Long contractAmount,
         LocalDate startDate,
-        LocalDate endDate) {
+        @Nullable LocalDate endDate) {
 
-    public ProjectCreateRequest toDomainRequest() {
-        return new ProjectCreateRequest(
+    public ProjectCreateCommand toCommand() {
+        return new ProjectCreateCommand(
                 partyId,
                 leadDepartmentId,
                 code,

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectCreateResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectCreateResponse.java
@@ -1,0 +1,9 @@
+package kr.co.abacus.abms.adapter.api.project.dto;
+
+public record ProjectCreateResponse(Long projectId) {
+
+    public static ProjectCreateResponse of(Long projectId) {
+        return new ProjectCreateResponse(projectId);
+    }
+
+}

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectResponse.java
@@ -35,11 +35,11 @@ public record ProjectResponse(
                 project.getPeriod().endDate());
     }
 
-    public static ProjectResponse from(ProjectSummary summary, String partyName) {
+    public static ProjectResponse from(ProjectSummary summary) {
         return new ProjectResponse(
                 summary.projectId(),
                 summary.partyId(),
-                partyName,
+                summary.partyName(),
                 summary.code(),
                 summary.name(),
                 summary.description(),

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectUpdateApiRequest.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectUpdateApiRequest.java
@@ -2,8 +2,10 @@ package kr.co.abacus.abms.adapter.api.project.dto;
 
 import java.time.LocalDate;
 
+import org.jspecify.annotations.Nullable;
+
+import kr.co.abacus.abms.application.project.dto.ProjectUpdateCommand;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
-import kr.co.abacus.abms.domain.project.ProjectUpdateRequest;
 
 public record ProjectUpdateApiRequest(
         Long partyId,
@@ -13,15 +15,15 @@ public record ProjectUpdateApiRequest(
         String status,
         Long contractAmount,
         LocalDate startDate,
-        LocalDate endDate) {
+        @Nullable LocalDate endDate) {
 
-    public ProjectUpdateRequest toDomainRequest() {
-        return new ProjectUpdateRequest(
-                partyId, // Added partyId
+    public ProjectUpdateCommand toCommand() {
+        return new ProjectUpdateCommand(
+                partyId,
                 leadDepartmentId,
                 name,
                 description,
-                ProjectStatus.valueOf(status), // Conversion added
+                ProjectStatus.valueOf(status),
                 contractAmount,
                 startDate,
                 endDate);

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectUpdateResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/project/dto/ProjectUpdateResponse.java
@@ -1,0 +1,9 @@
+package kr.co.abacus.abms.adapter.api.project.dto;
+
+public record ProjectUpdateResponse(Long projectId) {
+
+    public static ProjectUpdateResponse of(Long projectId) {
+        return new ProjectUpdateResponse(projectId);
+    }
+
+}

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/party/PartyApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/party/PartyApiTest.java
@@ -108,12 +108,12 @@ class PartyApiTest extends ApiIntegrationTestBase {
                 "010-0000-0000",
                 "contact2@test.com")));
 
-        projectRepository.save(Project.create(ProjectFixture.createProjectCreateRequest(
-                "PRJ-PARTY-001", "협력사 프로젝트 1", party.getId(), 1L)));
-        projectRepository.save(Project.create(ProjectFixture.createProjectCreateRequest(
-                "PRJ-PARTY-002", "협력사 프로젝트 2", party.getId(), 1L)));
-        projectRepository.save(Project.create(ProjectFixture.createProjectCreateRequest(
-                "PRJ-OTHER-001", "다른 협력사 프로젝트", otherParty.getId(), 1L)));
+        projectRepository.save(ProjectFixture.createProject(
+                "PRJ-PARTY-001", "협력사 프로젝트 1", party.getId(), 1L));
+        projectRepository.save(ProjectFixture.createProject(
+                "PRJ-PARTY-002", "협력사 프로젝트 2", party.getId(), 1L));
+        projectRepository.save(ProjectFixture.createProject(
+                "PRJ-OTHER-001", "다른 협력사 프로젝트", otherParty.getId(), 1L));
         flushAndClear();
 
         var response = restTestClient.get()
@@ -180,7 +180,7 @@ class PartyApiTest extends ApiIntegrationTestBase {
     }
 
     private Project createProject(String code, Long partyId, ProjectStatus status, long contractAmount) {
-        return Project.create(new kr.co.abacus.abms.domain.project.ProjectCreateRequest(
+        return Project.create(
                 partyId,
                 1L,
                 code,
@@ -190,7 +190,7 @@ class PartyApiTest extends ApiIntegrationTestBase {
                 contractAmount,
                 java.time.LocalDate.of(2024, 1, 1),
                 java.time.LocalDate.of(2024, 12, 31)
-        ));
+        );
     }
 
 }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/project/ProjectApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/project/ProjectApiTest.java
@@ -2,16 +2,17 @@ package kr.co.abacus.abms.adapter.api.project;
 
 import kr.co.abacus.abms.adapter.api.common.PageResponse;
 import kr.co.abacus.abms.adapter.api.project.dto.ProjectCreateApiRequest;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectCreateResponse;
 import kr.co.abacus.abms.adapter.api.project.dto.ProjectDetailResponse;
 import kr.co.abacus.abms.adapter.api.project.dto.ProjectResponse;
 import kr.co.abacus.abms.adapter.api.project.dto.ProjectUpdateApiRequest;
+import kr.co.abacus.abms.adapter.api.project.dto.ProjectUpdateResponse;
 import kr.co.abacus.abms.application.party.outbound.PartyRepository;
 import kr.co.abacus.abms.application.project.dto.ProjectOverviewSummary;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.domain.party.Party;
 import kr.co.abacus.abms.domain.party.PartyCreateRequest;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectFixture;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 import kr.co.abacus.abms.support.ApiIntegrationTestBase;
@@ -60,25 +61,24 @@ class ProjectApiTest extends ApiIntegrationTestBase {
         String requestJson = objectMapper.writeValueAsString(request);
 
         // When & Then
-        ProjectResponse response = restTestClient.post()
+        ProjectCreateResponse response = restTestClient.post()
                 .uri("/api/projects")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(requestJson)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(ProjectResponse.class)
+                .expectBody(ProjectCreateResponse.class)
                 .returnResult()
                 .getResponseBody();
 
         assertThat(response).isNotNull();
         assertThat(response.projectId()).isNotNull();
-        assertThat(response.code()).isEqualTo("PRJ-TEST-001");
-        assertThat(response.name()).isEqualTo("테스트 프로젝트");
-        assertThat(response.statusDescription()).isEqualTo("예약");
 
         flushAndClear();
         Project savedProject = projectRepository.findById(response.projectId()).orElseThrow();
         assertThat(savedProject.getCode()).isEqualTo("PRJ-TEST-001");
+        assertThat(savedProject.getName()).isEqualTo("테스트 프로젝트");
+        assertThat(savedProject.getStatus()).isEqualTo(ProjectStatus.SCHEDULED);
     }
 
     @Test
@@ -127,8 +127,8 @@ class ProjectApiTest extends ApiIntegrationTestBase {
                         .path("/api/projects")
                         .queryParam("name", "알파")
                         .queryParam("statuses", ProjectStatus.IN_PROGRESS.name())
-                        .queryParam("startDate", "2024-01-01")
-                        .queryParam("endDate", "2024-12-31")
+                        .queryParam("periodStart", "2024-01-01")
+                        .queryParam("periodEnd", "2024-12-31")
                         .queryParam("page", 0)
                         .queryParam("size", 10)
                         .build())
@@ -236,19 +236,18 @@ class ProjectApiTest extends ApiIntegrationTestBase {
         String requestJson = objectMapper.writeValueAsString(request);
 
         // When & Then
-        ProjectResponse response = restTestClient.put()
+        ProjectUpdateResponse response = restTestClient.put()
                 .uri("/api/projects/{id}", project.getId())
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(requestJson)
                 .exchange()
                 .expectStatus().isOk()
-                .expectBody(ProjectResponse.class)
+                .expectBody(ProjectUpdateResponse.class)
                 .returnResult()
                 .getResponseBody();
 
         assertThat(response).isNotNull();
-        assertThat(response.name()).isEqualTo("수정된 프로젝트명");
-        assertThat(response.statusDescription()).isEqualTo("진행 중");
+        assertThat(response.projectId()).isEqualTo(project.getId());
 
         flushAndClear();
         Project updatedProject = projectRepository.findById(project.getId()).orElseThrow();
@@ -266,16 +265,10 @@ class ProjectApiTest extends ApiIntegrationTestBase {
         flushAndClear();
 
         // When & Then
-        ProjectResponse response = restTestClient.patch()
+        restTestClient.patch()
                 .uri("/api/projects/{id}/complete", project.getId())
                 .exchange()
-                .expectStatus().isOk()
-                .expectBody(ProjectResponse.class)
-                .returnResult()
-                .getResponseBody();
-
-        assertThat(response).isNotNull();
-        assertThat(response.statusDescription()).isEqualTo("완료");
+                .expectStatus().isNoContent();
 
         flushAndClear();
         Project completedProject = projectRepository.findById(project.getId()).orElseThrow();
@@ -293,16 +286,10 @@ class ProjectApiTest extends ApiIntegrationTestBase {
         flushAndClear();
 
         // When & Then
-        ProjectResponse response = restTestClient.patch()
+        restTestClient.patch()
                 .uri("/api/projects/{id}/cancel", project.getId())
                 .exchange()
-                .expectStatus().isOk()
-                .expectBody(ProjectResponse.class)
-                .returnResult()
-                .getResponseBody();
-
-        assertThat(response).isNotNull();
-        assertThat(response.statusDescription()).isEqualTo("취소");
+                .expectStatus().isNoContent();
 
         flushAndClear();
         Project cancelledProject = projectRepository.findById(project.getId()).orElseThrow();
@@ -409,7 +396,7 @@ class ProjectApiTest extends ApiIntegrationTestBase {
     // }
 
     private Project createProject(String code, String name, Long partyId, Long leadDepartmentId, ProjectStatus status, LocalDate startDate) {
-        return Project.create(new ProjectCreateRequest(
+        return Project.create(
                 partyId,
                 leadDepartmentId,
                 code,
@@ -418,7 +405,7 @@ class ProjectApiTest extends ApiIntegrationTestBase {
                 status,
                 100_000_000L,
                 startDate,
-                startDate.plusMonths(6)));
+                startDate.plusMonths(6));
     }
 
     private Long createParty(String name) {

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/party/outbound/PartyRepositoryTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/party/outbound/PartyRepositoryTest.java
@@ -75,7 +75,7 @@ class PartyRepositoryTest extends IntegrationTestBase {
     }
 
     private Project createProject(String code, Long partyId, ProjectStatus status, long contractAmount) {
-        return Project.create(new kr.co.abacus.abms.domain.project.ProjectCreateRequest(
+        return Project.create(
                 partyId,
                 1L,
                 code,
@@ -85,7 +85,7 @@ class PartyRepositoryTest extends IntegrationTestBase {
                 contractAmount,
                 java.time.LocalDate.of(2024, 1, 1),
                 java.time.LocalDate.of(2024, 12, 31)
-        ));
+        );
     }
 
 }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectFinderTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectFinderTest.java
@@ -12,11 +12,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import kr.co.abacus.abms.application.party.outbound.PartyRepository;
 import kr.co.abacus.abms.application.project.dto.ProjectSearchCondition;
 import kr.co.abacus.abms.application.project.dto.ProjectSummary;
+import kr.co.abacus.abms.domain.party.Party;
+import kr.co.abacus.abms.domain.party.PartyCreateRequest;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectNotFoundException;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 import kr.co.abacus.abms.support.IntegrationTestBase;
@@ -29,6 +31,9 @@ class ProjectFinderTest extends IntegrationTestBase {
 
     @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private PartyRepository partyRepository;
 
     @Test
     @DisplayName("프로젝트 ID로 조회")
@@ -86,9 +91,9 @@ class ProjectFinderTest extends IntegrationTestBase {
         Long otherPartyId = 2L;
         Long leadDepartmentId = 1L;
 
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-001", "프로젝트1", partyId, leadDepartmentId)));
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-002", "프로젝트2", partyId, leadDepartmentId)));
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-003", "프로젝트3", otherPartyId, leadDepartmentId)));
+        projectRepository.save(createProject("PRJ-001", "프로젝트1", partyId, leadDepartmentId));
+        projectRepository.save(createProject("PRJ-002", "프로젝트2", partyId, leadDepartmentId));
+        projectRepository.save(createProject("PRJ-003", "프로젝트3", otherPartyId, leadDepartmentId));
         flushAndClear();
 
         List<Project> projects = projectFinder.findAllByPartyId(partyId);
@@ -117,33 +122,35 @@ class ProjectFinderTest extends IntegrationTestBase {
     @Test
     @DisplayName("프로젝트 조건에 따른 검색")
     void search() {
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-001", "알파 프로젝트", 1L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2024, 1, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-002", "알파 보조", 1L, 1L, ProjectStatus.COMPLETED,
-                LocalDate.of(2024, 2, 5)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-003", "알파 프로젝트", 2L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2024, 3, 1)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-004", "알파 프로젝트", 1L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2023, 5, 1)));
+        Long alphaPartyId = createParty("알파 협력사");
+        Long betaPartyId = createParty("베타 협력사");
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-001", "알파 프로젝트", alphaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2023, 12, 20), LocalDate.of(2024, 1, 15)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-002", "알파 보조", alphaPartyId, 1L, ProjectStatus.COMPLETED,
+                LocalDate.of(2024, 2, 5), LocalDate.of(2024, 2, 28)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-003", "알파 프로젝트", betaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2024, 3, 1), LocalDate.of(2024, 8, 31)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-004", "알파 프로젝트", alphaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2023, 5, 1), LocalDate.of(2023, 12, 15)));
         flushAndClear();
 
         ProjectSearchCondition condition = new ProjectSearchCondition(
                 "알파",
                 List.of(ProjectStatus.IN_PROGRESS),
-                List.of(1L),
+                List.of(alphaPartyId),
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2024, 12, 31));
 
         Page<ProjectSummary> projects = projectFinder.search(condition, PageRequest.of(0, 10));
 
         assertThat(projects).hasSize(1)
-                .extracting(ProjectSummary::code)
-                .containsExactly("PRJ-ALPHA-001");
+                .extracting(ProjectSummary::code, ProjectSummary::partyName)
+                .containsExactly(tuple("PRJ-ALPHA-001", "알파 협력사"));
     }
 
     private Project createProjectForSearch(String code, String name, Long partyId, Long leadDepartmentId, ProjectStatus status,
-                                           LocalDate startDate) {
-        return Project.create(new ProjectCreateRequest(
+                                           LocalDate startDate, LocalDate endDate) {
+        return Project.create(
                 partyId,
                 leadDepartmentId,
                 code,
@@ -152,7 +159,12 @@ class ProjectFinderTest extends IntegrationTestBase {
                 status,
                 100_000_000L,
                 startDate,
-                startDate.plusMonths(6)));
+                endDate);
+    }
+
+    private Long createParty(String name) {
+        Party party = partyRepository.save(Party.create(new PartyCreateRequest(name, null, null, null, null)));
+        return party.getIdOrThrow();
     }
 
 }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectManagerTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectManagerTest.java
@@ -1,0 +1,103 @@
+package kr.co.abacus.abms.application.project.inbound;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.co.abacus.abms.application.party.outbound.PartyRepository;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
+import kr.co.abacus.abms.application.project.dto.ProjectUpdateCommand;
+import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
+import kr.co.abacus.abms.domain.party.Party;
+import kr.co.abacus.abms.domain.party.PartyCreateRequest;
+import kr.co.abacus.abms.domain.project.Project;
+import kr.co.abacus.abms.domain.project.ProjectStatus;
+import kr.co.abacus.abms.support.IntegrationTestBase;
+
+@DisplayName("프로젝트 관리 (ProjectManager)")
+class ProjectManagerTest extends IntegrationTestBase {
+
+    @Autowired
+    private ProjectManager projectManager;
+
+    @Autowired
+    private ProjectFinder projectFinder;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @Test
+    @DisplayName("command 기반으로 프로젝트를 생성한다")
+    void create() {
+        Long partyId = createParty("생성 협력사");
+
+        Long projectId = projectManager.create(new ProjectCreateCommand(
+                partyId,
+                1L,
+                "PRJ-CMD-001",
+                "command 생성 프로젝트",
+                "설명",
+                ProjectStatus.SCHEDULED,
+                100_000_000L,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 12, 31)
+        ));
+        flushAndClear();
+
+        Project project = projectFinder.find(projectId);
+        assertThat(project.getCode()).isEqualTo("PRJ-CMD-001");
+        assertThat(project.getPartyId()).isEqualTo(partyId);
+    }
+
+    @Test
+    @DisplayName("command 기반으로 프로젝트를 수정한다")
+    void update() {
+        Long oldPartyId = createParty("기존 협력사");
+        Long newPartyId = createParty("변경 협력사");
+        Project project = projectRepository.save(Project.create(
+                oldPartyId,
+                1L,
+                "PRJ-CMD-UPDATE-001",
+                "기존 프로젝트",
+                "설명",
+                ProjectStatus.IN_PROGRESS,
+                100_000_000L,
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 12, 31)
+        ));
+        flushAndClear();
+
+        Long projectId = projectManager.update(project.getIdOrThrow(), new ProjectUpdateCommand(
+                newPartyId,
+                1L,
+                "수정된 프로젝트",
+                "수정 설명",
+                ProjectStatus.ON_HOLD,
+                150_000_000L,
+                LocalDate.of(2024, 2, 1),
+                LocalDate.of(2025, 1, 31)
+        ));
+        flushAndClear();
+
+        Project updated = projectFinder.find(projectId);
+        assertThat(updated.getPartyId()).isEqualTo(newPartyId);
+        assertThat(updated.getName()).isEqualTo("수정된 프로젝트");
+        assertThat(updated.getStatus()).isEqualTo(ProjectStatus.ON_HOLD);
+        assertThat(updated.getContractAmount().amount().longValue()).isEqualTo(150_000_000L);
+        assertThat(updated.getPeriod().startDate()).isEqualTo(LocalDate.of(2024, 2, 1));
+        assertThat(updated.getPeriod().endDate()).isEqualTo(LocalDate.of(2025, 1, 31));
+    }
+
+    private Long createParty(String name) {
+        Party party = partyRepository.save(Party.create(new PartyCreateRequest(name, null, null, null, null)));
+        return party.getIdOrThrow();
+    }
+
+}

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectRevenuePlanFinderTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/inbound/ProjectRevenuePlanFinderTest.java
@@ -18,7 +18,6 @@ import kr.co.abacus.abms.application.project.dto.ProjectSummary;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.application.project.outbound.ProjectRevenuePlanRepository;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectNotFoundException;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlan;
 import kr.co.abacus.abms.domain.project.ProjectStatus;

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/outbound/ProjectRepositoryTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/project/outbound/ProjectRepositoryTest.java
@@ -13,11 +13,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import kr.co.abacus.abms.application.party.outbound.PartyRepository;
 import kr.co.abacus.abms.application.project.dto.ProjectOverviewSummary;
 import kr.co.abacus.abms.application.project.dto.ProjectSearchCondition;
 import kr.co.abacus.abms.application.project.dto.ProjectSummary;
+import kr.co.abacus.abms.domain.party.Party;
+import kr.co.abacus.abms.domain.party.PartyCreateRequest;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
 import kr.co.abacus.abms.support.IntegrationTestBase;
 
@@ -25,6 +27,9 @@ class ProjectRepositoryTest extends IntegrationTestBase {
 
     @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private PartyRepository partyRepository;
 
     @Test
     @DisplayName("프로젝트 저장")
@@ -131,9 +136,9 @@ class ProjectRepositoryTest extends IntegrationTestBase {
         Long otherPartyId = 2L;
         Long leadDepartmentId = 1L;
 
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-001", "프로젝트1", partyId, leadDepartmentId)));
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-002", "프로젝트2", partyId, leadDepartmentId)));
-        projectRepository.save(Project.create(createProjectCreateRequest("PRJ-003", "프로젝트3", otherPartyId, leadDepartmentId)));
+        projectRepository.save(createProject("PRJ-001", "프로젝트1", partyId, leadDepartmentId));
+        projectRepository.save(createProject("PRJ-002", "프로젝트2", partyId, leadDepartmentId));
+        projectRepository.save(createProject("PRJ-003", "프로젝트3", otherPartyId, leadDepartmentId));
         flushAndClear();
 
         List<Project> projects = projectRepository.findAllByPartyIdAndDeletedFalse(partyId);
@@ -164,49 +169,53 @@ class ProjectRepositoryTest extends IntegrationTestBase {
     @Test
     @DisplayName("프로젝트 조건에 따른 검색")
     void search() {
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-001", "알파 프로젝트", 1L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2024, 1, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-002", "알파 보조", 1L, 1L, ProjectStatus.COMPLETED,
-                LocalDate.of(2024, 2, 5)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-003", "알파 프로젝트", 2L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2024, 3, 1)));
-        projectRepository.save(createProjectForSearch("PRJ-ALPHA-004", "알파 프로젝트", 1L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2023, 5, 1)));
+        Long alphaPartyId = createParty("알파 협력사");
+        Long betaPartyId = createParty("베타 협력사");
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-001", "알파 프로젝트", alphaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2023, 12, 20), LocalDate.of(2024, 1, 15)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-002", "알파 보조", alphaPartyId, 1L, ProjectStatus.COMPLETED,
+                LocalDate.of(2024, 2, 5), LocalDate.of(2024, 2, 28)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-003", "알파 프로젝트", betaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2024, 3, 1), LocalDate.of(2024, 8, 31)));
+        projectRepository.save(createProjectForSearch("PRJ-ALPHA-004", "알파 프로젝트", alphaPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2023, 5, 1), LocalDate.of(2023, 12, 15)));
         flushAndClear();
 
         ProjectSearchCondition condition = new ProjectSearchCondition(
                 "알파",
                 List.of(ProjectStatus.IN_PROGRESS),
-                List.of(1L),
+                List.of(alphaPartyId),
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2024, 12, 31));
 
         Page<ProjectSummary> projects = projectRepository.search(condition, PageRequest.of(0, 10));
 
         assertThat(projects).hasSize(1)
-                .extracting(ProjectSummary::code)
-                .containsExactly("PRJ-ALPHA-001");
+                .extracting(ProjectSummary::code, ProjectSummary::partyName)
+                .containsExactly(tuple("PRJ-ALPHA-001", "알파 협력사"));
     }
 
     @Test
     @DisplayName("프로젝트 요약 정보를 집계한다")
     void summarize() {
-        projectRepository.save(createProjectForSearch("PRJ-SUM-001", "요약 프로젝트 1", 1L, 1L, ProjectStatus.SCHEDULED,
-                LocalDate.of(2024, 1, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-SUM-002", "요약 프로젝트 2", 1L, 1L, ProjectStatus.IN_PROGRESS,
-                LocalDate.of(2024, 2, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-SUM-003", "요약 프로젝트 3", 1L, 1L, ProjectStatus.COMPLETED,
-                LocalDate.of(2024, 3, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-SUM-004", "요약 프로젝트 4", 1L, 1L, ProjectStatus.ON_HOLD,
-                LocalDate.of(2024, 4, 10)));
-        projectRepository.save(createProjectForSearch("PRJ-SUM-005", "요약 프로젝트 5", 2L, 1L, ProjectStatus.CANCELLED,
-                LocalDate.of(2024, 5, 10)));
+        Long summaryPartyId = createParty("요약 협력사");
+        Long otherPartyId = createParty("다른 협력사");
+        projectRepository.save(createProjectForSearch("PRJ-SUM-001", "요약 프로젝트 1", summaryPartyId, 1L, ProjectStatus.SCHEDULED,
+                LocalDate.of(2024, 1, 10), LocalDate.of(2024, 6, 30)));
+        projectRepository.save(createProjectForSearch("PRJ-SUM-002", "요약 프로젝트 2", summaryPartyId, 1L, ProjectStatus.IN_PROGRESS,
+                LocalDate.of(2024, 2, 10), LocalDate.of(2024, 7, 31)));
+        projectRepository.save(createProjectForSearch("PRJ-SUM-003", "요약 프로젝트 3", summaryPartyId, 1L, ProjectStatus.COMPLETED,
+                LocalDate.of(2024, 3, 10), LocalDate.of(2024, 8, 31)));
+        projectRepository.save(createProjectForSearch("PRJ-SUM-004", "요약 프로젝트 4", summaryPartyId, 1L, ProjectStatus.ON_HOLD,
+                LocalDate.of(2024, 4, 10), LocalDate.of(2024, 9, 30)));
+        projectRepository.save(createProjectForSearch("PRJ-SUM-005", "요약 프로젝트 5", otherPartyId, 1L, ProjectStatus.CANCELLED,
+                LocalDate.of(2024, 5, 10), LocalDate.of(2024, 10, 31)));
         flushAndClear();
 
         ProjectOverviewSummary summary = projectRepository.summarize(new ProjectSearchCondition(
                 "요약",
                 null,
-                List.of(1L),
+                List.of(summaryPartyId),
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(2024, 12, 31)
         ));
@@ -221,8 +230,8 @@ class ProjectRepositoryTest extends IntegrationTestBase {
     }
 
     private Project createProjectForSearch(String code, String name, Long partyId, Long leadDepartmentId, ProjectStatus status,
-                                           LocalDate startDate) {
-        return Project.create(new ProjectCreateRequest(
+                                           LocalDate startDate, LocalDate endDate) {
+        return Project.create(
                 partyId,
                 leadDepartmentId,
                 code,
@@ -231,7 +240,12 @@ class ProjectRepositoryTest extends IntegrationTestBase {
                 status,
                 100_000_000L,
                 startDate,
-                startDate.plusMonths(6)));
+                endDate);
+    }
+
+    private Long createParty(String name) {
+        Party party = partyRepository.save(Party.create(new PartyCreateRequest(name, null, null, null, null)));
+        return party.getIdOrThrow();
     }
 
 }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/summary/inbound/MonthlyRevenueSummaryManagerTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/summary/inbound/MonthlyRevenueSummaryManagerTest.java
@@ -24,7 +24,6 @@ import kr.co.abacus.abms.domain.employee.EmployeeCostPolicy;
 import kr.co.abacus.abms.domain.employee.EmployeeType;
 import kr.co.abacus.abms.domain.payroll.Payroll;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlan;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlanCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectStatus;
@@ -248,17 +247,15 @@ class MonthlyRevenueSummaryManagerTest extends IntegrationTestBase {
         // 1. [프로젝트 A] (매출 O, 비용 O -> 흑자)
         Project projectA = projectRepository.save(
             Project.create(
-                new ProjectCreateRequest(
-                    1L,
-                    10L,
-                    "PRJ-0001",
-                    "차세대 빌링 구축",
-                    "차세대 빌링 구축 시스템입니다.",
-                    ProjectStatus.IN_PROGRESS,
-                    10_000_000L,
-                    LocalDate.of(2026, 1, 1),
-                    LocalDate.of(2026, 6, 30)
-                )
+                1L,
+                10L,
+                "PRJ-0001",
+                "차세대 빌링 구축",
+                "차세대 빌링 구축 시스템입니다.",
+                ProjectStatus.IN_PROGRESS,
+                10_000_000L,
+                LocalDate.of(2026, 1, 1),
+                LocalDate.of(2026, 6, 30)
             )
         );
 

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/ProjectExcelService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/ProjectExcelService.java
@@ -1,6 +1,7 @@
 package kr.co.abacus.abms.application.project;
 
 import kr.co.abacus.abms.application.party.outbound.PartyRepository;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
 import kr.co.abacus.abms.application.project.dto.ProjectExcelUploadResult;
 import kr.co.abacus.abms.application.project.dto.ProjectSearchCondition;
 import kr.co.abacus.abms.application.project.inbound.ProjectManager;
@@ -9,7 +10,6 @@ import kr.co.abacus.abms.application.project.outbound.ProjectExcelImporter;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.domain.party.Party;
 import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
 import kr.co.abacus.abms.domain.project.ProjectExcelException;
 
 import lombok.RequiredArgsConstructor;
@@ -46,14 +46,14 @@ public class ProjectExcelService {
 
     @Transactional
     public ProjectExcelUploadResult upload(InputStream inputStream) {
-        List<ProjectCreateRequest> requests = projectExcelImporter.importProjects(inputStream, this::getPartyIdByName);
+        List<ProjectCreateCommand> commands = projectExcelImporter.importProjects(inputStream, this::getPartyIdByName);
 
         List<ProjectExcelUploadResult.ExcelFailure> excelFailures = new ArrayList<>();
         int successCount = 0;
 
-        for (int i = 0; i < requests.size(); i++) {
+        for (int i = 0; i < commands.size(); i++) {
             try {
-                projectManager.create(requests.get(i));
+                projectManager.create(commands.get(i));
                 successCount++;
             } catch (Exception ex) {
                 excelFailures.add(new ProjectExcelUploadResult.ExcelFailure(i + 2, resolveMessage(ex)));

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/ProjectModifyService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/ProjectModifyService.java
@@ -7,13 +7,13 @@ import lombok.RequiredArgsConstructor;
 
 import kr.co.abacus.abms.application.project.inbound.ProjectFinder;
 import kr.co.abacus.abms.application.project.inbound.ProjectManager;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
+import kr.co.abacus.abms.application.project.dto.ProjectUpdateCommand;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.application.party.outbound.PartyRepository;
 import kr.co.abacus.abms.domain.party.PartyNotFoundException;
 import kr.co.abacus.abms.domain.project.Project;
 import kr.co.abacus.abms.domain.project.ProjectCodeDuplicateException;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
-import kr.co.abacus.abms.domain.project.ProjectUpdateRequest;
 
 @RequiredArgsConstructor
 @Transactional
@@ -25,40 +25,57 @@ public class ProjectModifyService implements ProjectManager {
     private final PartyRepository partyRepository;
 
     @Override
-    public Project create(ProjectCreateRequest request) {
-        if (projectRepository.existsByCode(request.code())) {
-            throw new ProjectCodeDuplicateException("이미 존재하는 프로젝트 코드입니다: " + request.code());
+    public Long create(ProjectCreateCommand command) {
+        if (projectRepository.existsByCode(command.code())) {
+            throw new ProjectCodeDuplicateException("이미 존재하는 프로젝트 코드입니다: " + command.code());
         }
-        validateActivePartyExists(request.partyId());
+        validateActivePartyExists(command.partyId());
 
-        Project project = Project.create(request);
+        Project project = Project.create(
+                command.partyId(),
+                command.leadDepartmentId(),
+                command.code(),
+                command.name(),
+                command.description(),
+                command.status(),
+                command.contractAmount(),
+                command.startDate(),
+                command.endDate());
 
-        return projectRepository.save(project);
+        return projectRepository.save(project).getIdOrThrow();
     }
 
     @Override
-    public Project update(Long id, ProjectUpdateRequest request) {
+    public Long update(Long id, ProjectUpdateCommand command) {
         Project project = projectFinder.find(id);
-        validateActivePartyExists(request.partyId());
-        project.update(request);
+        validateActivePartyExists(command.partyId());
+        project.update(
+                command.partyId(),
+                command.leadDepartmentId(),
+                command.name(),
+                command.description(),
+                command.status(),
+                command.contractAmount(),
+                command.startDate(),
+                command.endDate());
 
-        return projectRepository.save(project);
+        return projectRepository.save(project).getIdOrThrow();
     }
 
     @Override
-    public Project complete(Long id) {
+    public void complete(Long id) {
         Project project = projectFinder.find(id);
         project.complete();
 
-        return projectRepository.save(project);
+        projectRepository.save(project);
     }
 
     @Override
-    public Project cancel(Long id) {
+    public void cancel(Long id) {
         Project project = projectFinder.find(id);
         project.cancel();
 
-        return projectRepository.save(project);
+        projectRepository.save(project);
     }
 
     @Override

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectCreateCommand.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectCreateCommand.java
@@ -1,10 +1,12 @@
-package kr.co.abacus.abms.domain.project;
+package kr.co.abacus.abms.application.project.dto;
 
 import java.time.LocalDate;
 
 import org.jspecify.annotations.Nullable;
 
-public record ProjectCreateRequest(
+import kr.co.abacus.abms.domain.project.ProjectStatus;
+
+public record ProjectCreateCommand(
         Long partyId,
         Long leadDepartmentId,
         String code,
@@ -13,6 +15,6 @@ public record ProjectCreateRequest(
         ProjectStatus status,
         Long contractAmount,
         LocalDate startDate,
-        LocalDate endDate) {
+        @Nullable LocalDate endDate) {
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectSearchCondition.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectSearchCondition.java
@@ -11,7 +11,7 @@ public record ProjectSearchCondition(
         @Nullable String name,
         @Nullable List<ProjectStatus> statuses,
         @Nullable List<Long> partyIds,
-        @Nullable LocalDate startDate,
-        @Nullable LocalDate endDate) {
+        @Nullable LocalDate periodStart,
+        @Nullable LocalDate periodEnd) {
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectSummary.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectSummary.java
@@ -10,6 +10,7 @@ import kr.co.abacus.abms.domain.shared.Money;
 public record ProjectSummary(
         Long projectId,
         Long partyId,
+        String partyName,
         String code,
         String name,
         @Nullable String description,

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectUpdateCommand.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/dto/ProjectUpdateCommand.java
@@ -1,10 +1,12 @@
-package kr.co.abacus.abms.domain.project;
+package kr.co.abacus.abms.application.project.dto;
 
 import java.time.LocalDate;
 
 import org.jspecify.annotations.Nullable;
 
-public record ProjectUpdateRequest(
+import kr.co.abacus.abms.domain.project.ProjectStatus;
+
+public record ProjectUpdateCommand(
         Long partyId,
         Long leadDepartmentId,
         String name,

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/inbound/ProjectManager.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/inbound/ProjectManager.java
@@ -1,18 +1,17 @@
 package kr.co.abacus.abms.application.project.inbound;
 
-import kr.co.abacus.abms.domain.project.Project;
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
-import kr.co.abacus.abms.domain.project.ProjectUpdateRequest;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
+import kr.co.abacus.abms.application.project.dto.ProjectUpdateCommand;
 
 public interface ProjectManager {
 
-    Project create(ProjectCreateRequest request);
+    Long create(ProjectCreateCommand command);
 
-    Project update(Long id, ProjectUpdateRequest request);
+    Long update(Long id, ProjectUpdateCommand command);
 
-    Project complete(Long id);
+    void complete(Long id);
 
-    Project cancel(Long id);
+    void cancel(Long id);
 
     void delete(Long id);
 

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/project/outbound/ProjectExcelImporter.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/project/outbound/ProjectExcelImporter.java
@@ -4,10 +4,10 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.function.Function;
 
-import kr.co.abacus.abms.domain.project.ProjectCreateRequest;
+import kr.co.abacus.abms.application.project.dto.ProjectCreateCommand;
 
 public interface ProjectExcelImporter {
 
-    List<ProjectCreateRequest> importProjects(InputStream inputStream, Function<String, Long> partyLookup);
+    List<ProjectCreateCommand> importProjects(InputStream inputStream, Function<String, Long> partyLookup);
 
 }

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/project/Project.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/project/Project.java
@@ -2,6 +2,8 @@ package kr.co.abacus.abms.domain.project;
 
 import static java.util.Objects.*;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -54,7 +56,7 @@ public class Project extends AbstractEntity {
 
     @Embedded
     @AttributeOverride(name = "startDate", column = @Column(name = "start_date", nullable = false))
-    @AttributeOverride(name = "endDate", column = @Column(name = "end_date", nullable = false))
+    @AttributeOverride(name = "endDate", column = @Column(name = "end_date"))
     private Period period;
 
     private Project(Long partyId, Long leadDepartmentId, String code, String name, @Nullable String description, ProjectStatus status,
@@ -69,26 +71,43 @@ public class Project extends AbstractEntity {
         this.period = period;
     }
 
-    public static Project create(ProjectCreateRequest request) {
+    public static Project create(
+            Long partyId,
+            Long leadDepartmentId,
+            String code,
+            String name,
+            @Nullable String description,
+            ProjectStatus status,
+            Long contractAmount,
+            LocalDate startDate,
+            @Nullable LocalDate endDate) {
         return new Project(
-                requireNonNull(request.partyId()),
-                requireNonNull(request.leadDepartmentId()),
-                requireNonNull(request.code()),
-                requireNonNull(request.name()),
-                request.description(),
-                requireNonNull(request.status()),
-                Money.wons(requireNonNull(request.contractAmount())),
-                new Period(requireNonNull(request.startDate()), requireNonNull(request.endDate())));
+                requireNonNull(partyId),
+                requireNonNull(leadDepartmentId),
+                requireNonNull(code),
+                requireNonNull(name),
+                description,
+                requireNonNull(status),
+                Money.wons(requireNonNull(contractAmount)),
+                new Period(requireNonNull(startDate), endDate));
     }
 
-    public void update(ProjectUpdateRequest request) {
-        this.partyId = requireNonNull(request.partyId());
-        this.leadDepartmentId = requireNonNull(request.leadDepartmentId());
-        this.name = requireNonNull(request.name());
-        this.description = request.description();
-        this.status = requireNonNull(request.status());
-        this.contractAmount = Money.wons(requireNonNull(request.contractAmount()));
-        this.period = new Period(requireNonNull(request.startDate()), request.endDate());
+    public void update(
+            Long partyId,
+            Long leadDepartmentId,
+            String name,
+            @Nullable String description,
+            ProjectStatus status,
+            Long contractAmount,
+            LocalDate startDate,
+            @Nullable LocalDate endDate) {
+        this.partyId = requireNonNull(partyId);
+        this.leadDepartmentId = requireNonNull(leadDepartmentId);
+        this.name = requireNonNull(name);
+        this.description = description;
+        this.status = requireNonNull(status);
+        this.contractAmount = Money.wons(requireNonNull(contractAmount));
+        this.period = new Period(requireNonNull(startDate), endDate);
     }
 
     public void complete() {

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/project/ProjectFixture.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/project/ProjectFixture.java
@@ -5,19 +5,7 @@ import java.time.LocalDate;
 public class ProjectFixture {
 
     public static Project createProject() {
-        return Project.create(createProjectCreateRequest());
-    }
-
-    public static Project createProject(Long partyId) {
-        return Project.create(createProjectCreateRequest(partyId));
-    }
-
-    public static Project createProject(String code) {
-        return Project.create(createProjectCreateRequest(code));
-    }
-
-    public static ProjectCreateRequest createProjectCreateRequest() {
-        return new ProjectCreateRequest(
+        return Project.create(
                 1L,
                 1L,
                 "PRJ-001",
@@ -29,8 +17,8 @@ public class ProjectFixture {
                 LocalDate.of(2024, 12, 31));
     }
 
-    public static ProjectCreateRequest createProjectCreateRequest(Long partyId) {
-        return new ProjectCreateRequest(
+    public static Project createProject(Long partyId) {
+        return Project.create(
                 partyId,
                 1L,
                 "PRJ-001",
@@ -42,8 +30,8 @@ public class ProjectFixture {
                 LocalDate.of(2024, 12, 31));
     }
 
-    public static ProjectCreateRequest createProjectCreateRequest(String code) {
-        return new ProjectCreateRequest(
+    public static Project createProject(String code) {
+        return Project.create(
                 1L,
                 1L,
                 code,
@@ -55,8 +43,8 @@ public class ProjectFixture {
                 LocalDate.of(2024, 12, 31));
     }
 
-    public static ProjectCreateRequest createProjectCreateRequest(String code, String name, Long partyId, Long leadDepartmentId) {
-        return new ProjectCreateRequest(
+    public static Project createProject(String code, String name, Long partyId, Long leadDepartmentId) {
+        return Project.create(
                 partyId,
                 leadDepartmentId,
                 code,

--- a/abms-domain/src/test/java/kr/co/abacus/abms/domain/project/ProjectTest.java
+++ b/abms-domain/src/test/java/kr/co/abacus/abms/domain/project/ProjectTest.java
@@ -17,7 +17,7 @@ class ProjectTest {
     @Test
     @DisplayName("프로젝트 생성 - 필수 정보와 초기 상태")
     void create() {
-        Project project = Project.create(new ProjectCreateRequest(
+        Project project = Project.create(
                 1L,
                 4L,
                 "PROJECT_123",
@@ -26,7 +26,7 @@ class ProjectTest {
                 ProjectStatus.CANCELLED,
                 32_000_000L,
                 LocalDate.of(2024, 1, 1),
-                LocalDate.of(2024, 12, 31)));
+                LocalDate.of(2024, 12, 31));
 
         assertThat(project.getCode()).isEqualTo("PROJECT_123");
         assertThat(project.getName()).isEqualTo("This is a test project");
@@ -39,7 +39,7 @@ class ProjectTest {
     @Test
     @DisplayName("프로젝트 정보 수정")
     void update() {
-        Project project = Project.create(new ProjectCreateRequest(
+        Project project = Project.create(
                 1L,
                 4L,
                 "PROJECT_123",
@@ -48,9 +48,9 @@ class ProjectTest {
                 ProjectStatus.CANCELLED,
                 32_000_000L,
                 LocalDate.of(2024, 1, 1),
-                LocalDate.of(2024, 12, 31)));
+                LocalDate.of(2024, 12, 31));
 
-        project.update(new ProjectUpdateRequest(
+        project.update(
                 99L,
                 4L,
                 "Updated Project Name",
@@ -58,7 +58,7 @@ class ProjectTest {
                 ProjectStatus.IN_PROGRESS,
                 45_000_000L,
                 LocalDate.of(2024, 2, 1),
-                LocalDate.of(2024, 12, 31)));
+                LocalDate.of(2024, 12, 31));
 
         assertThat(project.getName()).isEqualTo("Updated Project Name");
         assertThat(project.getDescription()).isEqualTo("Updated description");
@@ -70,7 +70,7 @@ class ProjectTest {
     @Test
     @DisplayName("프로젝트 완료 처리")
     void complete() {
-        Project project = Project.create(new ProjectCreateRequest(
+        Project project = Project.create(
                 1L,
                 4L,
                 "PROJECT_123",
@@ -79,7 +79,7 @@ class ProjectTest {
                 ProjectStatus.IN_PROGRESS,
                 32_000_000L,
                 LocalDate.of(2024, 1, 1),
-                LocalDate.of(2024, 12, 31)));
+                LocalDate.of(2024, 12, 31));
 
         project.complete();
 
@@ -89,7 +89,7 @@ class ProjectTest {
     @Test
     @DisplayName("프로젝트 취소 처리")
     void cancel() {
-        Project project = Project.create(new ProjectCreateRequest(
+        Project project = Project.create(
                 1L,
                 4L,
                 "PROJECT_123",
@@ -98,7 +98,7 @@ class ProjectTest {
                 ProjectStatus.IN_PROGRESS,
                 32_000_000L,
                 LocalDate.of(2024, 1, 1),
-                LocalDate.of(2024, 12, 31)));
+                LocalDate.of(2024, 12, 31));
 
         project.cancel();
 

--- a/frontend/src/core/query/normalizeParams.ts
+++ b/frontend/src/core/query/normalizeParams.ts
@@ -137,8 +137,8 @@ export interface NormalizedProjectSearchParams {
   name: string | null;
   statuses: string[];
   partyIds: number[];
-  startDate: string | null;
-  endDate: string | null;
+  periodStart: string | null;
+  periodEnd: string | null;
   sort: string | null;
 }
 
@@ -149,8 +149,8 @@ export function normalizeProjectSearchParams(params: Record<string, unknown> = {
     name: toNullableString(params.name),
     statuses: toSortedUniqueStrings(params.statuses),
     partyIds: toSortedUniqueNumbers(params.partyIds),
-    startDate: toIsoDateString(params.startDate),
-    endDate: toIsoDateString(params.endDate),
+    periodStart: toIsoDateString(params.periodStart),
+    periodEnd: toIsoDateString(params.periodEnd),
     sort: toNullableString(params.sort),
   };
 }

--- a/frontend/src/features/project/composables/useProjectQuerySync.ts
+++ b/frontend/src/features/project/composables/useProjectQuerySync.ts
@@ -74,10 +74,10 @@ export function useProjectQuerySync(options: UseProjectQuerySyncOptions) {
     const start = toIsoDateString(dateRange.value?.start);
     const end = toIsoDateString(dateRange.value?.end);
     if (start) {
-      params.startDate = start;
+      params.periodStart = start;
     }
     if (end) {
-      params.endDate = end;
+      params.periodEnd = end;
     }
 
     const sortState = sorting.value[0];
@@ -104,11 +104,11 @@ export function useProjectQuerySync(options: UseProjectQuerySyncOptions) {
     if (params.partyIds?.length) {
       query.partyIds = serializeArrayFilter(params.partyIds.map(String));
     }
-    if (params.startDate) {
-      query.startDate = params.startDate;
+    if (params.periodStart) {
+      query.periodStart = params.periodStart;
     }
-    if (params.endDate) {
-      query.endDate = params.endDate;
+    if (params.periodEnd) {
+      query.periodEnd = params.periodEnd;
     }
     if (params.sort) {
       query.sort = params.sort;
@@ -142,10 +142,10 @@ export function useProjectQuerySync(options: UseProjectQuerySyncOptions) {
       filters.push({ id: 'partyId', value: partyIds });
     }
 
-    const startDate = deserializeSingleFilter(rawQuery, 'startDate');
-    const endDate = deserializeSingleFilter(rawQuery, 'endDate');
-    if (startDate && endDate) {
-      dateRange.value = { start: startDate, end: endDate };
+    const periodStart = deserializeSingleFilter(rawQuery, 'periodStart');
+    const periodEnd = deserializeSingleFilter(rawQuery, 'periodEnd');
+    if (periodStart || periodEnd) {
+      dateRange.value = { start: periodStart ?? undefined, end: periodEnd ?? undefined };
     } else {
       dateRange.value = null;
     }
@@ -269,7 +269,7 @@ export function useProjectQuerySync(options: UseProjectQuerySyncOptions) {
 
   function mapSortId(id: string): string | null {
     if (id === 'period') {
-      return 'startDate';
+      return 'periodStart';
     }
     return id;
   }
@@ -282,7 +282,7 @@ export function useProjectQuerySync(options: UseProjectQuerySyncOptions) {
     if (!first?.id) {
       return [];
     }
-    const mappedId = first.id === 'startDate' || first.id === 'endDate' ? 'period' : first.id;
+    const mappedId = first.id === 'periodStart' || first.id === 'periodEnd' ? 'period' : first.id;
     return [{ id: mappedId, desc: first.desc }];
   }
 

--- a/frontend/src/features/project/models/projectListItem.ts
+++ b/frontend/src/features/project/models/projectListItem.ts
@@ -21,8 +21,8 @@ export interface ProjectSearchParams {
   name?: string;
   statuses?: string[];
   partyIds?: number[];
-  startDate?: string;
-  endDate?: string;
+  periodStart?: string;
+  periodEnd?: string;
   sort?: string;
 }
 

--- a/frontend/src/features/project/queries/useProjectQueries.ts
+++ b/frontend/src/features/project/queries/useProjectQueries.ts
@@ -116,8 +116,8 @@ export function useUpdateProjectMutation() {
   return useMutation({
     mutationFn: (variables: { projectId: number; data: ProjectUpdateData }) =>
       repository.update(variables.projectId, variables.data),
-    onSuccess: async (updated) => {
-      await invalidateProjectSideEffects(updated.projectId);
+    onSuccess: async (_updated, variables) => {
+      await invalidateProjectSideEffects(variables.projectId);
     },
   });
 }
@@ -138,8 +138,8 @@ export function useCompleteProjectMutation() {
 
   return useMutation({
     mutationFn: (projectId: number) => repository.complete(projectId),
-    onSuccess: async (updated) => {
-      await invalidateProjectSideEffects(updated.projectId);
+    onSuccess: async (_data, projectId) => {
+      await invalidateProjectSideEffects(projectId);
     },
   });
 }
@@ -149,8 +149,8 @@ export function useCancelProjectMutation() {
 
   return useMutation({
     mutationFn: (projectId: number) => repository.cancel(projectId),
-    onSuccess: async (updated) => {
-      await invalidateProjectSideEffects(updated.projectId);
+    onSuccess: async (_data, projectId) => {
+      await invalidateProjectSideEffects(projectId);
     },
   });
 }

--- a/frontend/src/features/project/repository/ProjectRepository.ts
+++ b/frontend/src/features/project/repository/ProjectRepository.ts
@@ -32,8 +32,12 @@ export interface ProjectOverviewSummaryParams {
   name?: string;
   statuses?: string[];
   partyIds?: number[];
-  startDate?: string;
-  endDate?: string;
+  periodStart?: string;
+  periodEnd?: string;
+}
+
+export interface ProjectWriteResult {
+  projectId: number;
 }
 
 @singleton()
@@ -91,11 +95,12 @@ export default class ProjectRepository {
   /**
    * 프로젝트 생성
    */
-  async create(data: ProjectCreateData): Promise<ProjectDetail> {
-    const response = await this.httpRepository.post({
+  async create(data: ProjectCreateData): Promise<ProjectWriteResult> {
+    const response = await this.httpRepository.post<ProjectWriteResult>({
       path: '/api/projects',
       data: {
         partyId: data.partyId,
+        leadDepartmentId: data.leadDepartmentId,
         code: data.code,
         name: data.name,
         description: data.description || null,
@@ -106,17 +111,20 @@ export default class ProjectRepository {
       },
     });
 
-    return mapProjectDetail(response);
+    return {
+      projectId: Number(response?.projectId ?? 0),
+    };
   }
 
   /**
    * 프로젝트 수정
    */
-  async update(projectId: number, data: ProjectUpdateData): Promise<ProjectDetail> {
-    const response = await this.httpRepository.put({
+  async update(projectId: number, data: ProjectUpdateData): Promise<ProjectWriteResult> {
+    const response = await this.httpRepository.put<ProjectWriteResult>({
       path: `/api/projects/${projectId}`,
       data: {
         partyId: data.partyId,
+        leadDepartmentId: data.leadDepartmentId,
         name: data.name,
         description: data.description || null,
         status: data.status,
@@ -126,7 +134,9 @@ export default class ProjectRepository {
       },
     });
 
-    return mapProjectDetail(response);
+    return {
+      projectId: Number(response?.projectId ?? 0),
+    };
   }
 
   /**
@@ -141,23 +151,19 @@ export default class ProjectRepository {
   /**
    * 프로젝트 완료 처리
    */
-  async complete(projectId: number): Promise<ProjectDetail> {
-    const response = await this.httpRepository.patch({
+  async complete(projectId: number): Promise<void> {
+    await this.httpRepository.patch({
       path: `/api/projects/${projectId}/complete`,
     });
-
-    return mapProjectDetail(response);
   }
 
   /**
    * 프로젝트 취소 처리
    */
-  async cancel(projectId: number): Promise<ProjectDetail> {
-    const response = await this.httpRepository.patch({
+  async cancel(projectId: number): Promise<void> {
+    await this.httpRepository.patch({
       path: `/api/projects/${projectId}/cancel`,
     });
-
-    return mapProjectDetail(response);
   }
 
   /**
@@ -238,12 +244,12 @@ function buildRequestParams(params: ProjectSearchParams): Record<string, string>
     query.name = params.name;
   }
 
-  if (params.startDate) {
-    query.startDate = params.startDate;
+  if (params.periodStart) {
+    query.periodStart = params.periodStart;
   }
 
-  if (params.endDate) {
-    query.endDate = params.endDate;
+  if (params.periodEnd) {
+    query.periodEnd = params.periodEnd;
   }
 
   if (params.sort) {
@@ -268,12 +274,12 @@ function buildOverviewRequestParams(params: ProjectOverviewSummaryParams): Recor
     query.name = params.name;
   }
 
-  if (params.startDate) {
-    query.startDate = params.startDate;
+  if (params.periodStart) {
+    query.periodStart = params.periodStart;
   }
 
-  if (params.endDate) {
-    query.endDate = params.endDate;
+  if (params.periodEnd) {
+    query.periodEnd = params.periodEnd;
   }
 
   const arrayFields: (keyof ProjectOverviewSummaryParams)[] = ['statuses', 'partyIds'];

--- a/frontend/src/features/project/views/ProjectListView.vue
+++ b/frontend/src/features/project/views/ProjectListView.vue
@@ -13,10 +13,8 @@
         @reset="handleResetFilters"
       >
         <template #filters>
-          <!-- 날짜 검색 유형 선택 -->
-          <!-- 날짜 범위 필터 -->
           <div class="flex items-center gap-2">
-            <DateRangeFilter v-model="dateRange" placeholder="계약일 날짜 범위 선택" />
+            <DateRangeFilter v-model="dateRange" placeholder="프로젝트 기간 선택" />
           </div>
 
           <DataTableFacetedFilter
@@ -408,8 +406,8 @@ const summaryParams = computed(() => {
     name: params.name,
     statuses: params.statuses,
     partyIds: params.partyIds,
-    startDate: params.startDate,
-    endDate: params.endDate,
+    periodStart: params.periodStart,
+    periodEnd: params.periodEnd,
   };
 });
 const projectsQuery = useProjectListQuery(searchParams);
@@ -486,14 +484,14 @@ function getSearchParams(): ProjectSearchParams {
   }
 
   if (dateRange.value?.start) {
-    params.startDate =
+    params.periodStart =
       dateRange.value.start instanceof Date
         ? dateRange.value.start.toISOString().split('T')[0]
         : (dateRange.value.start as string);
   }
 
   if (dateRange.value?.end) {
-    params.endDate =
+    params.periodEnd =
       dateRange.value.end instanceof Date
         ? dateRange.value.end.toISOString().split('T')[0]
         : (dateRange.value.end as string);
@@ -502,7 +500,8 @@ function getSearchParams(): ProjectSearchParams {
   if (sorting.value.length > 0) {
     const s = sorting.value[0];
     if (s) {
-      params.sort = `${s.id},${s.desc ? 'desc' : 'asc'}`;
+      const sortId = s.id === 'period' ? 'periodStart' : s.id;
+      params.sort = `${sortId},${s.desc ? 'desc' : 'asc'}`;
     }
   }
 


### PR DESCRIPTION
## 변경 요약
- 프로젝트 write 흐름을 command 기반으로 정리하고 write API 응답을 create/update id 반환 및 complete/cancel no-content로 분리했습니다.
- 프로젝트 검색 날짜 파라미터를 `periodStart`/`periodEnd`로 변경하고 기간 겹침 기준으로 조회하도록 수정했습니다.
- 프로젝트 목록 조회가 `partyName`을 summary 단계에서 직접 포함하도록 바꿔 API 후처리 조회를 제거했습니다.
- domain 레이어에서 `ProjectCreateRequest`/`ProjectUpdateRequest`를 제거하고 값 기반 생성/수정 메서드로 정리했습니다.

## 관련 이슈 (필수)
- Closes #67

## 핵심 검증 (필수)
- [x] 로컬에서 핵심 시나리오를 검증했습니다.
- 검증 내용 요약:
  - ./gradlew :abms-domain:test --tests "kr.co.abacus.abms.domain.project.ProjectTest" :abms-api-boot:test --tests "kr.co.abacus.abms.adapter.api.project.ProjectApiTest" --tests "kr.co.abacus.abms.application.project.outbound.ProjectRepositoryTest" --tests "kr.co.abacus.abms.application.project.inbound.ProjectFinderTest" --tests "kr.co.abacus.abms.application.project.inbound.ProjectManagerTest" --tests "kr.co.abacus.abms.application.summary.inbound.MonthlyRevenueSummaryManagerTest"
  - npm run test:unit -- src/features/project/views/ProjectListView.spec.ts
  - npm run typecheck

## 증빙 자료 (조건부 필수)
- [x] UI 변경 있음: 프로젝트 목록 날짜 필터 의미와 요청 파라미터를 정리함
- [ ] UI 변경 없음
- [ ] 동작 흐름 확인 필요: GIF/MP4 첨부

## 영향도 (필수)
- API 변경: [x] 있음 [ ] 없음
- DB 스키마/데이터 마이그레이션: [ ] 있음 [x] 없음
- ENV 변수 추가/변경: [ ] 있음 [x] 없음

## 리뷰/머지 체크
- [ ] 팀원 1명 승인 완료
- [ ] CI 체크 통과

## Hotfix 예외
- [ ] 이 PR은 `hotfix/*` 이다.
- [ ] 사후 리뷰 이슈를 생성했고 24시간 내 리뷰한다.