### PR TITLE
feat(employee): refine department scope ux

### DIFF
--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthMeResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/AuthMeResponse.java
@@ -2,11 +2,15 @@ package kr.co.abacus.abms.adapter.api.auth.dto;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import kr.co.abacus.abms.application.auth.dto.AuthenticatedUserInfo;
 
 public record AuthMeResponse(
         String name,
         String email,
+        @Nullable Long employeeId,
+        @Nullable Long departmentId,
         List<AuthPermissionResponse> permissions
 ) {
 
@@ -14,6 +18,8 @@ public record AuthMeResponse(
         return new AuthMeResponse(
                 userInfo.name(),
                 userInfo.email(),
+                userInfo.employeeId(),
+                userInfo.departmentId(),
                 userInfo.permissions().stream()
                         .map(AuthPermissionResponse::from)
                         .toList()

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
@@ -192,6 +192,8 @@ class AuthApiTest extends ApiIntegrationTestBase {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.email").value(USERNAME))
                 .andExpect(jsonPath("$.name").value("인증사용자"))
+                .andExpect(jsonPath("$.employeeId").isNumber())
+                .andExpect(jsonPath("$.departmentId").isNumber())
                 .andExpect(jsonPath("$.permissions[0].code").value("employee.manage"))
                 .andExpect(jsonPath("$.permissions[0].scopes[0]").value("ALL"))
                 .andExpect(jsonPath("$.permissions[1].code").value("employee.read"))

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/AuthFinderTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/AuthFinderTest.java
@@ -98,6 +98,8 @@ class AuthFinderTest extends IntegrationTestBase {
 
         assertThat(currentUser.name()).isEqualTo("조회사용자");
         assertThat(currentUser.email()).isEqualTo(email);
+        assertThat(currentUser.employeeId()).isEqualTo(employee.getIdOrThrow());
+        assertThat(currentUser.departmentId()).isEqualTo(employee.getDepartmentId());
         assertThat(currentUser.permissions()).containsExactly(
                 new GrantedPermissionDetail("employee.read", java.util.Set.of(PermissionScope.ALL))
         );
@@ -110,6 +112,8 @@ class AuthFinderTest extends IntegrationTestBase {
 
         assertThat(currentUser.name()).isEqualTo("fallback-user");
         assertThat(currentUser.email()).isEqualTo("fallback-user@abms.co");
+        assertThat(currentUser.employeeId()).isNull();
+        assertThat(currentUser.departmentId()).isNull();
         assertThat(currentUser.permissions()).isEmpty();
     }
 
@@ -130,6 +134,8 @@ class AuthFinderTest extends IntegrationTestBase {
 
         assertThat(currentUser.name()).isEqualTo("deleted-account");
         assertThat(currentUser.email()).isEqualTo(email);
+        assertThat(currentUser.employeeId()).isNull();
+        assertThat(currentUser.departmentId()).isNull();
         assertThat(currentUser.permissions()).isEmpty();
     }
 
@@ -150,6 +156,8 @@ class AuthFinderTest extends IntegrationTestBase {
 
         assertThat(currentUser.name()).isEqualTo("deleted-employee");
         assertThat(currentUser.email()).isEqualTo(email);
+        assertThat(currentUser.employeeId()).isNull();
+        assertThat(currentUser.departmentId()).isNull();
         assertThat(currentUser.permissions()).isEmpty();
     }
 

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthQueryService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthQueryService.java
@@ -48,6 +48,8 @@ public class AuthQueryService implements AuthFinder {
                 .map(employee -> new AuthenticatedUserInfo(
                         employee.getName(),
                         employee.getEmail().address(),
+                        employee.getIdOrThrow(),
+                        employee.getDepartmentId(),
                         permissionFinder.findPermissions(account.getIdOrThrow()).permissions()
                 ))
                 .orElseGet(() -> fallbackUserInfo(account.getUsername().address()));
@@ -56,7 +58,7 @@ public class AuthQueryService implements AuthFinder {
     private AuthenticatedUserInfo fallbackUserInfo(String email) {
         String localPart = email.split("@")[0];
         String normalizedName = localPart.isBlank() ? email : localPart;
-        return new AuthenticatedUserInfo(normalizedName, email, java.util.List.of());
+        return new AuthenticatedUserInfo(normalizedName, email, null, null, java.util.List.of());
     }
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/AuthenticatedUserInfo.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/AuthenticatedUserInfo.java
@@ -2,11 +2,15 @@ package kr.co.abacus.abms.application.auth.dto;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import kr.co.abacus.abms.application.permission.dto.GrantedPermissionDetail;
 
 public record AuthenticatedUserInfo(
         String name,
         String email,
+        @Nullable Long employeeId,
+        @Nullable Long departmentId,
         List<GrantedPermissionDetail> permissions
 ) {
 

--- a/frontend/src/core/router/index.ts
+++ b/frontend/src/core/router/index.ts
@@ -82,6 +82,7 @@ const routes = [
           title: '부서',
           layout: SidebarLayout,
           padding: 'flush',
+          forceSessionRefresh: true,
           breadcrumbs: [
             {
               title: '대시보드',
@@ -102,6 +103,7 @@ const routes = [
           title: '부서',
           layout: SidebarLayout,
           padding: 'flush',
+          forceSessionRefresh: true,
           breadcrumbs: [
             {
               title: '대시보드',
@@ -364,8 +366,9 @@ router.beforeEach(async (to, from) => {
 
   const requiredPermission =
     typeof to.meta?.requiredPermission === 'string' ? to.meta.requiredPermission : null;
+  const forceSessionRefresh = Boolean(requiredPermission || to.meta?.forceSessionRefresh);
 
-  const sessionValid = await ensureServerSessionValid(Boolean(requiredPermission));
+  const sessionValid = await ensureServerSessionValid(forceSessionRefresh);
   if (!sessionValid) {
     return resolveLoginRedirect(to.fullPath);
   }

--- a/frontend/src/features/auth/repository/AuthRepository.ts
+++ b/frontend/src/features/auth/repository/AuthRepository.ts
@@ -23,6 +23,8 @@ interface ChangePasswordPayload {
 export interface AuthMeResponse {
   name: string;
   email: string;
+  employeeId: number | null;
+  departmentId: number | null;
   permissions: AuthPermissionResponse[];
 }
 

--- a/frontend/src/features/auth/repository/__tests__/AuthRepository.spec.ts
+++ b/frontend/src/features/auth/repository/__tests__/AuthRepository.spec.ts
@@ -90,6 +90,8 @@ describe('AuthRepository', () => {
     httpGet.mockResolvedValueOnce({
       name: '인증사용자',
       email: 'auth-user@abacus.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         {
           code: 'employee.read',
@@ -106,6 +108,8 @@ describe('AuthRepository', () => {
     expect(result).toEqual({
       name: '인증사용자',
       email: 'auth-user@abacus.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         {
           code: 'employee.read',

--- a/frontend/src/features/auth/session.spec.ts
+++ b/frontend/src/features/auth/session.spec.ts
@@ -51,6 +51,8 @@ describe('auth session', () => {
     setStoredUser({
       email: 'user@abms.co.kr',
       name: '사용자',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         {
           code: 'employee.read',
@@ -66,6 +68,8 @@ describe('auth session', () => {
     expect(getStoredUser()).toEqual({
       email: 'user@abms.co.kr',
       name: '사용자',
+      employeeId: 1,
+      departmentId: 10,
       avatar: '',
       permissions: [
         {
@@ -96,6 +100,8 @@ describe('auth session', () => {
     expect(getStoredUser()).toEqual({
       email: 'legacy@abms.co.kr',
       name: 'Legacy',
+      employeeId: null,
+      departmentId: null,
       avatar: '',
       permissions: [],
     });
@@ -106,6 +112,8 @@ describe('auth session', () => {
     fetchMeMock.mockResolvedValue({
       email: 'user@abms.co.kr',
       name: '사용자',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         {
           code: 'employee.read',
@@ -118,6 +126,8 @@ describe('auth session', () => {
       {
         email: 'user@abms.co.kr',
         name: '사용자',
+        employeeId: null,
+        departmentId: null,
         permissions: [],
       },
       { validated: false },
@@ -131,6 +141,8 @@ describe('auth session', () => {
         scopes: ['SELF'],
       },
     ]);
+    expect(getStoredUser()?.employeeId).toBe(1);
+    expect(getStoredUser()?.departmentId).toBe(10);
 
     await expect(ensureServerSessionValid()).resolves.toBe(true);
     expect(fetchMeMock).toHaveBeenCalledTimes(1);

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -10,6 +10,8 @@ const EMPLOYEE_STORAGE_KEY = 'employee';
 interface StoredUser {
   name: string;
   email: string;
+  employeeId: number | null;
+  departmentId: number | null;
   avatar?: string;
   permissions: StoredPermission[];
 }
@@ -25,6 +27,10 @@ export interface StoredPermission {
 
 let isSessionValidated = false;
 let validatingPromise: Promise<boolean> | null = null;
+let isSessionSyncInitialized = false;
+let lastForcedValidationAt = 0;
+
+const SESSION_REFRESH_INTERVAL_MS = 10_000;
 
 function normalizePermissions(rawPermissions: unknown): StoredPermission[] {
   if (!Array.isArray(rawPermissions)) {
@@ -71,6 +77,8 @@ function parseStoredUser(raw: string | null): StoredUser | null {
     return {
       email: parsed.email.trim(),
       name: typeof parsed.name === 'string' && parsed.name.trim().length > 0 ? parsed.name : 'User',
+      employeeId: typeof parsed.employeeId === 'number' ? parsed.employeeId : null,
+      departmentId: typeof parsed.departmentId === 'number' ? parsed.departmentId : null,
       avatar: typeof parsed.avatar === 'string' ? parsed.avatar : '',
       permissions: normalizePermissions(parsed.permissions),
     };
@@ -94,6 +102,8 @@ export function setStoredUser(
   const normalized: StoredUser = {
     name: user.name?.trim() || 'User',
     email: user.email.trim(),
+    employeeId: 'employeeId' in user && typeof user.employeeId === 'number' ? user.employeeId : null,
+    departmentId: 'departmentId' in user && typeof user.departmentId === 'number' ? user.departmentId : null,
     avatar: 'avatar' in user && typeof user.avatar === 'string' ? user.avatar : '',
     permissions: 'permissions' in user ? normalizePermissions(user.permissions) : [],
   };
@@ -120,11 +130,13 @@ export function clearStoredUser(): void {
   localStorage.removeItem(EMPLOYEE_STORAGE_KEY);
   isSessionValidated = false;
   validatingPromise = null;
+  lastForcedValidationAt = 0;
   resetCsrfInitialization();
 }
 
 export function markSessionNeedsValidation(): void {
   isSessionValidated = false;
+  lastForcedValidationAt = 0;
 }
 
 export async function ensureServerSessionValid(forceRefresh = false): Promise<boolean> {
@@ -157,4 +169,42 @@ export async function ensureServerSessionValid(forceRefresh = false): Promise<bo
   }
 
   return validatingPromise;
+}
+
+export async function refreshStoredUserSession(force = false): Promise<void> {
+  if (!hasStoredUser()) {
+    return;
+  }
+
+  const now = Date.now();
+  if (!force && now - lastForcedValidationAt < SESSION_REFRESH_INTERVAL_MS) {
+    return;
+  }
+
+  await ensureServerSessionValid(true);
+  lastForcedValidationAt = Date.now();
+}
+
+export function initializeSessionSync(): void {
+  if (isSessionSyncInitialized || typeof window === 'undefined') {
+    return;
+  }
+
+  const syncSession = () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      return;
+    }
+    if (!hasStoredUser()) {
+      return;
+    }
+
+    void refreshStoredUserSession();
+  };
+
+  window.addEventListener('focus', syncSession);
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', syncSession);
+  }
+
+  isSessionSyncInitialized = true;
 }

--- a/frontend/src/features/auth/views/AuthLoginView.spec.ts
+++ b/frontend/src/features/auth/views/AuthLoginView.spec.ts
@@ -65,6 +65,8 @@ describe('AuthLoginView', () => {
       data: {
         email: 'user@abms.co.kr',
         name: '사용자',
+        employeeId: 1,
+        departmentId: 10,
         permissions: [
           {
             code: 'employee.read',
@@ -137,6 +139,8 @@ describe('AuthLoginView', () => {
     expect(setStoredUser).toHaveBeenCalledWith({
       email: 'user@abms.co.kr',
       name: '사용자',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         {
           code: 'employee.read',
@@ -159,6 +163,8 @@ describe('AuthLoginView', () => {
     expect(setStoredUser).toHaveBeenCalledWith({
       email: 'john.doe@abms.co.kr',
       name: 'John Doe',
+      employeeId: null,
+      departmentId: null,
       permissions: [],
     }, { validated: false });
   });

--- a/frontend/src/features/auth/views/AuthLoginView.vue
+++ b/frontend/src/features/auth/views/AuthLoginView.vue
@@ -153,6 +153,8 @@ async function submitLogin() {
     setStoredUser({
       email: resolvedEmail,
       name: resolvedName,
+      employeeId: null,
+      departmentId: null,
       permissions: [],
     }, { validated: false });
 

--- a/frontend/src/features/department/components/DepartmentDetailPanel.vue
+++ b/frontend/src/features/department/components/DepartmentDetailPanel.vue
@@ -78,7 +78,7 @@
           class="flex flex-col"
         >
           <TabsList class="rounded-lg bg-muted/30 p-1">
-            <TabsTrigger value="info" class="text-sm">팀 기본정보</TabsTrigger>
+            <TabsTrigger value="info" class="text-sm">부서 기본정보</TabsTrigger>
             <TabsTrigger value="employees" class="text-sm">직원</TabsTrigger>
             <TabsTrigger value="revenue" class="text-sm">매출</TabsTrigger>
           </TabsList>
@@ -141,7 +141,7 @@
                     메모
                   </dt>
                   <dd class="text-sm text-muted-foreground">
-                    팀별 KPI, 진행 중인 프로젝트 등 메모가 필요하다면 이 영역을 확장하세요.
+                    부서별 KPI, 진행 중인 프로젝트 등 메모가 필요하다면 이 영역을 확장하세요.
                   </dd>
                 </div>
               </div>
@@ -182,7 +182,7 @@
     >
       <h3 class="text-base font-semibold text-foreground">부서를 선택해 주세요</h3>
       <p class="mt-2 text-sm text-muted-foreground">
-        왼쪽 부서 목록에서 팀을 선택하면 이 영역에 상세 정보가 표시됩니다.
+        왼쪽 부서 목록에서 부서를 선택하면 이 영역에 상세 정보가 표시됩니다.
       </p>
     </div>
 

--- a/frontend/src/features/department/components/DepartmentEmployeeList.vue
+++ b/frontend/src/features/department/components/DepartmentEmployeeList.vue
@@ -118,7 +118,7 @@ import {
 import { departmentKeys, employeeKeys, queryClient } from '@/core/query';
 import {
   canEditOwnProfile,
-  canManageEmployees,
+  canManageEmployee,
   canViewEmployeeDetail,
 } from '@/features/employee/permissions';
 import { dispatchOpenProfileDialogEvent } from '@/features/auth/profileDialogEvents';
@@ -305,10 +305,13 @@ const totalPages = computed(() => {
   return typeof value === 'number' && value > 0 ? value : 1;
 });
 const totalElements = computed(() => departmentEmployeesQuery.data.value?.totalElements ?? 0);
+const employeePermissionContext = computed(() => ({
+  departmentChart: departmentChartQuery.data.value ?? [],
+}));
 
 // 이벤트 핸들러
 function handleViewEmployee(employee: EmployeeListItem) {
-  if (!canViewEmployeeDetail(employee.email)) {
+  if (!canViewEmployeeDetail(employee, employeePermissionContext.value)) {
     return;
   }
   router.push({
@@ -318,10 +321,10 @@ function handleViewEmployee(employee: EmployeeListItem) {
 }
 
 async function handleEditEmployee(employee: EmployeeListItem) {
-  if (!(canManageEmployees() || canEditOwnProfile(employee.email))) {
+  if (!(canManageEmployee(employee, employeePermissionContext.value) || canEditOwnProfile(employee))) {
     return;
   }
-  if (!canManageEmployees() && canEditOwnProfile(employee.email)) {
+  if (!canManageEmployee(employee, employeePermissionContext.value) && canEditOwnProfile(employee)) {
     dispatchOpenProfileDialogEvent({ openSelfProfileEditor: true });
     return;
   }
@@ -366,7 +369,7 @@ function handleCopyEmail(employee: EmployeeListItem) {
 }
 
 function handleDeleteEmployee(employee: EmployeeListItem) {
-  if (!canManageEmployees()) {
+  if (!canManageEmployee(employee, employeePermissionContext.value)) {
     return;
   }
   deletion.open(employee.employeeId, employee.name);
@@ -393,11 +396,14 @@ const columns = createEmployeeTableColumns(
     onCopyEmail: handleCopyEmail,
     onDeleteEmployee: handleDeleteEmployee,
     onNavigateToDepartment: handleNavigateToDepartment,
-    canViewEmployee: (employee) => canViewEmployeeDetail(employee.email),
-    canEditEmployee: (employee) => canManageEmployees() || canEditOwnProfile(employee.email),
-    canDeleteEmployee: () => canManageEmployees(),
+    canViewEmployee: (employee) => canViewEmployeeDetail(employee, employeePermissionContext.value),
+    canEditEmployee: (employee) =>
+      canManageEmployee(employee, employeePermissionContext.value) || canEditOwnProfile(employee),
+    canDeleteEmployee: (employee) => canManageEmployee(employee, employeePermissionContext.value),
     getEditActionLabel: (employee) =>
-      !canManageEmployees() && canEditOwnProfile(employee.email) ? '내 정보 수정' : '직원 편집',
+      !canManageEmployee(employee, employeePermissionContext.value) && canEditOwnProfile(employee)
+        ? '내 정보 수정'
+        : '직원 편집',
   },
   {
     excludeDepartmentColumn: true,

--- a/frontend/src/features/employee/permissions.spec.ts
+++ b/frontend/src/features/employee/permissions.spec.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  canAccessDepartmentEmployees,
+  canEditOwnProfile,
+  canManageEmployee,
+  canViewEmployeeDetail,
+} from '@/features/employee/permissions';
+
+const departmentChart = [
+  {
+    departmentId: 10,
+    departmentName: '개발본부',
+    departmentCode: 'DEV',
+    departmentType: 'DIVISION',
+    departmentLeader: null,
+    employeeCount: 3,
+    children: [
+      {
+        departmentId: 11,
+        departmentName: '개발팀',
+        departmentCode: 'DEV-TEAM',
+        departmentType: 'TEAM',
+        departmentLeader: null,
+        employeeCount: 2,
+        children: [],
+      },
+    ],
+  },
+];
+
+describe('employee permissions', () => {
+  const storage = new Map<string, string>();
+
+  beforeEach(() => {
+    storage.clear();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => {
+        storage.clear();
+      },
+    });
+  });
+
+  it('OWN_DEPARTMENT는 같은 부서 직원만 상세/관리 가능하다', () => {
+    localStorage.setItem(
+      'user',
+      JSON.stringify({
+        name: '홍길동',
+        email: 'hong@abms.co.kr',
+        employeeId: 1,
+        departmentId: 10,
+        permissions: [
+          { code: 'employee.read', scopes: ['OWN_DEPARTMENT'] },
+          { code: 'employee.write', scopes: ['OWN_DEPARTMENT'] },
+        ],
+      }),
+    );
+
+    expect(canViewEmployeeDetail({ employeeId: 2, departmentId: 10 }, { departmentChart })).toBe(true);
+    expect(canManageEmployee({ employeeId: 2, departmentId: 10 }, { departmentChart })).toBe(true);
+    expect(canViewEmployeeDetail({ employeeId: 3, departmentId: 11 }, { departmentChart })).toBe(false);
+    expect(canManageEmployee({ employeeId: 3, departmentId: 11 }, { departmentChart })).toBe(false);
+  });
+
+  it('OWN_DEPARTMENT_TREE는 하위 부서 직원까지 상세/관리 가능하다', () => {
+    localStorage.setItem(
+      'user',
+      JSON.stringify({
+        name: '홍길동',
+        email: 'hong@abms.co.kr',
+        employeeId: 1,
+        departmentId: 10,
+        permissions: [
+          { code: 'employee.read', scopes: ['OWN_DEPARTMENT_TREE'] },
+          { code: 'employee.write', scopes: ['OWN_DEPARTMENT_TREE'] },
+        ],
+      }),
+    );
+
+    expect(canViewEmployeeDetail({ employeeId: 3, departmentId: 11 }, { departmentChart })).toBe(true);
+    expect(canManageEmployee({ employeeId: 3, departmentId: 11 }, { departmentChart })).toBe(true);
+    expect(canAccessDepartmentEmployees(11, { departmentChart })).toBe(true);
+  });
+
+  it('SELF는 본인만 수정 가능하고 부서 직원 탭 접근은 허용하지 않는다', () => {
+    localStorage.setItem(
+      'user',
+      JSON.stringify({
+        name: '홍길동',
+        email: 'hong@abms.co.kr',
+        employeeId: 1,
+        departmentId: 10,
+        permissions: [
+          { code: 'employee.read', scopes: ['SELF'] },
+          { code: 'employee.write', scopes: ['SELF'] },
+        ],
+      }),
+    );
+
+    expect(canEditOwnProfile({ employeeId: 1, email: 'hong@abms.co.kr' })).toBe(true);
+    expect(canManageEmployee({ employeeId: 1, departmentId: 10 }, { departmentChart })).toBe(false);
+    expect(canAccessDepartmentEmployees(10, { departmentChart })).toBe(false);
+  });
+});

--- a/frontend/src/features/employee/permissions.ts
+++ b/frontend/src/features/employee/permissions.ts
@@ -1,3 +1,4 @@
+import type { DepartmentChartNode } from '@/features/department/models/department';
 import { getStoredPermissions, getStoredUser, hasStoredPermission } from '@/features/auth/session';
 
 const EMPLOYEE_READ = 'employee.read';
@@ -6,9 +7,33 @@ const EMPLOYEE_EXCEL_DOWNLOAD = 'employee.excel.download';
 const EMPLOYEE_EXCEL_UPLOAD = 'employee.excel.upload';
 const PERMISSION_GROUP_MANAGE = 'permission.group.manage';
 const SELF_SCOPE = 'SELF';
+const ALL_SCOPE = 'ALL';
+const OWN_DEPARTMENT_SCOPE = 'OWN_DEPARTMENT';
+const OWN_DEPARTMENT_TREE_SCOPE = 'OWN_DEPARTMENT_TREE';
+
+export interface EmployeePermissionTarget {
+  employeeId?: number | null;
+  email?: string | null;
+  departmentId?: number | null;
+}
+
+export interface EmployeePermissionContext {
+  departmentChart?: DepartmentChartNode[] | null;
+  currentEmployeeId?: number | null;
+  currentDepartmentId?: number | null;
+}
 
 function normalizeEmail(email: string | null | undefined): string {
   return typeof email === 'string' ? email.trim().toLowerCase() : '';
+}
+
+function resolveContext(context?: EmployeePermissionContext): Required<EmployeePermissionContext> {
+  const storedUser = getStoredUser();
+  return {
+    departmentChart: context?.departmentChart ?? null,
+    currentEmployeeId: context?.currentEmployeeId ?? storedUser?.employeeId ?? null,
+    currentDepartmentId: context?.currentDepartmentId ?? storedUser?.departmentId ?? null,
+  };
 }
 
 function getPermissionScopes(code: string): string[] {
@@ -17,13 +42,93 @@ function getPermissionScopes(code: string): string[] {
     .flatMap((permission) => permission.scopes);
 }
 
-function hasOnlySelfScope(code: string): boolean {
-  const scopes = getPermissionScopes(code);
-  return scopes.length > 0 && scopes.every((scope) => scope === SELF_SCOPE);
+function hasScope(code: string, scope: string): boolean {
+  return getPermissionScopes(code).includes(scope);
 }
 
-function hasNonSelfScope(code: string): boolean {
-  return getPermissionScopes(code).some((scope) => scope !== SELF_SCOPE);
+function hasAnyScope(code: string, scopes: string[]): boolean {
+  return getPermissionScopes(code).some((scope) => scopes.includes(scope));
+}
+
+function findDepartmentNode(
+  nodes: DepartmentChartNode[],
+  departmentId: number,
+): DepartmentChartNode | null {
+  for (const node of nodes) {
+    if (node.departmentId === departmentId) {
+      return node;
+    }
+
+    const found = findDepartmentNode(node.children ?? [], departmentId);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+function collectDepartmentTreeIds(
+  nodes: DepartmentChartNode[] | null | undefined,
+  rootDepartmentId: number | null,
+): Set<number> {
+  if (!Array.isArray(nodes) || nodes.length === 0 || rootDepartmentId == null) {
+    return new Set<number>();
+  }
+
+  const root = findDepartmentNode(nodes, rootDepartmentId);
+  if (!root) {
+    return new Set<number>([rootDepartmentId]);
+  }
+
+  const collected = new Set<number>();
+  const stack: DepartmentChartNode[] = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    collected.add(current.departmentId);
+    stack.push(...(current.children ?? []));
+  }
+
+  return collected;
+}
+
+function resolveDepartmentScopedIds(
+  code: string,
+  context?: EmployeePermissionContext,
+): Set<number> {
+  const resolvedContext = resolveContext(context);
+  const currentDepartmentId = resolvedContext.currentDepartmentId;
+  if (currentDepartmentId == null) {
+    return new Set<number>();
+  }
+
+  const scoped = new Set<number>();
+  if (hasScope(code, OWN_DEPARTMENT_SCOPE)) {
+    scoped.add(currentDepartmentId);
+  }
+  if (hasScope(code, OWN_DEPARTMENT_TREE_SCOPE)) {
+    collectDepartmentTreeIds(resolvedContext.departmentChart, currentDepartmentId).forEach((departmentId) => {
+      scoped.add(departmentId);
+    });
+  }
+
+  return scoped;
+}
+
+function matchesCurrentUser(target: EmployeePermissionTarget, context?: EmployeePermissionContext): boolean {
+  const resolvedContext = resolveContext(context);
+  if (
+    resolvedContext.currentEmployeeId != null &&
+    target.employeeId != null &&
+    resolvedContext.currentEmployeeId === target.employeeId
+  ) {
+    return true;
+  }
+
+  return isCurrentUserEmail(target.email);
 }
 
 function isCurrentUserEmail(email: string | null | undefined): boolean {
@@ -36,38 +141,63 @@ export function canReadEmployeeDetail(): boolean {
 }
 
 export function canDownloadEmployeeExcel(): boolean {
-  return hasStoredPermission(EMPLOYEE_EXCEL_DOWNLOAD);
+  return hasStoredPermission(EMPLOYEE_EXCEL_DOWNLOAD)
+    && hasAnyScope(EMPLOYEE_EXCEL_DOWNLOAD, [
+      ALL_SCOPE,
+      OWN_DEPARTMENT_SCOPE,
+      OWN_DEPARTMENT_TREE_SCOPE,
+      SELF_SCOPE,
+    ]);
 }
 
-export function canViewEmployeeDetail(employeeEmail: string | null | undefined): boolean {
+export function canViewEmployeeDetail(
+  target: EmployeePermissionTarget,
+  context?: EmployeePermissionContext,
+): boolean {
   if (!canReadEmployeeDetail()) {
     return false;
   }
 
-  if (hasNonSelfScope(EMPLOYEE_READ)) {
+  if (hasScope(EMPLOYEE_READ, ALL_SCOPE)) {
     return true;
   }
 
-  if (hasOnlySelfScope(EMPLOYEE_READ)) {
-    return isCurrentUserEmail(employeeEmail);
+  if (hasScope(EMPLOYEE_READ, SELF_SCOPE) && matchesCurrentUser(target, context)) {
+    return true;
+  }
+
+  if (target.departmentId != null) {
+    return resolveDepartmentScopedIds(EMPLOYEE_READ, context).has(target.departmentId);
   }
 
   return false;
 }
 
 export function canManageEmployees(): boolean {
-  return hasStoredPermission(EMPLOYEE_WRITE) && hasNonSelfScope(EMPLOYEE_WRITE);
+  return hasStoredPermission(EMPLOYEE_WRITE)
+    && hasAnyScope(EMPLOYEE_WRITE, [ALL_SCOPE, OWN_DEPARTMENT_SCOPE, OWN_DEPARTMENT_TREE_SCOPE]);
 }
 
-export function canManageEmployee(employeeEmail: string | null | undefined): boolean {
-  if (canManageEmployees()) {
+export function canManageEmployee(
+  target: EmployeePermissionTarget,
+  context?: EmployeePermissionContext,
+): boolean {
+  if (!hasStoredPermission(EMPLOYEE_WRITE)) {
+    return false;
+  }
+
+  if (hasScope(EMPLOYEE_WRITE, ALL_SCOPE)) {
     return true;
   }
 
-  return canEditOwnProfile(employeeEmail);
+  if (target.departmentId != null) {
+    return resolveDepartmentScopedIds(EMPLOYEE_WRITE, context).has(target.departmentId);
+  }
+
+  return false;
 }
 
-export function canEditOwnProfile(employeeEmail?: string | null): boolean {
+export function canEditOwnProfile(target?: string | EmployeePermissionTarget | null): boolean {
   if (!hasStoredPermission(EMPLOYEE_WRITE)) {
     return false;
   }
@@ -76,11 +206,15 @@ export function canEditOwnProfile(employeeEmail?: string | null): boolean {
     return false;
   }
 
-  if (employeeEmail == null) {
+  if (target == null) {
     return true;
   }
 
-  return isCurrentUserEmail(employeeEmail);
+  if (typeof target === 'string') {
+    return isCurrentUserEmail(target);
+  }
+
+  return matchesCurrentUser(target);
 }
 
 export function canAccessOwnProfileEditor(): boolean {
@@ -88,7 +222,23 @@ export function canAccessOwnProfileEditor(): boolean {
 }
 
 export function canUploadEmployeeExcel(): boolean {
-  return hasStoredPermission(EMPLOYEE_EXCEL_UPLOAD) && hasNonSelfScope(EMPLOYEE_EXCEL_UPLOAD);
+  return hasStoredPermission(EMPLOYEE_EXCEL_UPLOAD)
+    && hasAnyScope(EMPLOYEE_EXCEL_UPLOAD, [ALL_SCOPE, OWN_DEPARTMENT_SCOPE, OWN_DEPARTMENT_TREE_SCOPE]);
+}
+
+export function canAccessDepartmentEmployees(
+  departmentId: number | null | undefined,
+  context?: EmployeePermissionContext,
+): boolean {
+  if (!canReadEmployeeDetail() || departmentId == null) {
+    return false;
+  }
+
+  if (hasScope(EMPLOYEE_READ, ALL_SCOPE)) {
+    return true;
+  }
+
+  return resolveDepartmentScopedIds(EMPLOYEE_READ, context).has(departmentId);
 }
 
 export function canManagePermissionGroups(): boolean {

--- a/frontend/src/features/employee/queries/useEmployeeQueries.ts
+++ b/frontend/src/features/employee/queries/useEmployeeQueries.ts
@@ -7,6 +7,7 @@ import type { EmployeeCreatePayload } from '@/features/employee/models/employee'
 import type { EmployeeSearchParams } from '@/features/employee/models/employeeListItem';
 import type { EmployeeOverviewSummaryParams } from '@/features/employee/repository/EmployeeRepository';
 import AuthRepository from '@/features/auth/repository/AuthRepository';
+import { getStoredUser, markSessionNeedsValidation, refreshStoredUserSession } from '@/features/auth/session';
 
 async function invalidateEmployeeSideEffects(employeeId?: number) {
   const tasks: Promise<unknown>[] = [
@@ -15,11 +16,26 @@ async function invalidateEmployeeSideEffects(employeeId?: number) {
     queryClient.invalidateQueries({ queryKey: dashboardKeys.summary() }),
   ];
 
+  const currentUser = getStoredUser();
+  const isCurrentUserMutation = Boolean(
+    employeeId && currentUser?.employeeId && currentUser.employeeId === employeeId,
+  );
+
+  if (isCurrentUserMutation) {
+    tasks.push(queryClient.invalidateQueries({ queryKey: authKeys.me() }));
+    tasks.push(queryClient.invalidateQueries({ queryKey: employeeKeys.currentProfile() }));
+  }
+
   if (employeeId && employeeId > 0) {
     tasks.push(queryClient.invalidateQueries({ queryKey: employeeKeys.detail(employeeId) }));
   }
 
   await Promise.all(tasks);
+
+  if (isCurrentUserMutation) {
+    markSessionNeedsValidation();
+    await refreshStoredUserSession(true);
+  }
 }
 
 export function useEmployeesQuery(paramsRef: MaybeRefOrGetter<EmployeeSearchParams>) {
@@ -74,7 +90,11 @@ export function useCurrentEmployeeProfileQuery(enabledRef: MaybeRefOrGetter<bool
         queryFn: () => authRepository.fetchMe(),
       });
 
-      return employeeRepository.findCurrentByIdentity(me.name, me.email);
+      if (!me.employeeId || me.employeeId <= 0) {
+        throw new Error('현재 로그인한 직원 정보를 찾을 수 없습니다.');
+      }
+
+      return employeeRepository.findById(me.employeeId);
     },
     enabled,
   });

--- a/frontend/src/features/employee/views/EmployeeDetailView.spec.ts
+++ b/frontend/src/features/employee/views/EmployeeDetailView.spec.ts
@@ -25,6 +25,28 @@ const employeeData = ref({
   birthDate: '1990-01-01',
 });
 
+const departmentChartData = ref([
+  {
+    departmentId: 10,
+    departmentName: '개발본부',
+    departmentCode: 'DEV',
+    departmentType: 'DIVISION',
+    departmentLeader: null,
+    employeeCount: 1,
+    children: [
+      {
+        departmentId: 11,
+        departmentName: '개발팀',
+        departmentCode: 'DEV-TEAM',
+        departmentType: 'TEAM',
+        departmentLeader: null,
+        employeeCount: 1,
+        children: [],
+      },
+    ],
+  },
+]);
+
 const dispatchOpenProfileDialogEventMock = vi.fn();
 let storage: Record<string, string> = {};
 let EmployeeDetailViewComponent: Component;
@@ -47,7 +69,7 @@ vi.mock('@/features/employee/queries/useEmployeeQueries', () => ({
 
 vi.mock('@/features/department/queries/useDepartmentQueries', () => ({
   useDepartmentOrganizationChartQuery: () => ({
-    data: { value: [] },
+    data: departmentChartData,
   }),
 }));
 
@@ -161,12 +183,35 @@ describe('EmployeeDetailView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     storage = {};
+    employeeData.value = {
+      departmentId: 10,
+      departmentName: '개발팀',
+      employeeId: 1,
+      name: '홍길동',
+      email: 'hong@abms.co.kr',
+      position: '사원',
+      positionCode: 'ASSOCIATE',
+      status: '재직',
+      statusCode: 'ACTIVE',
+      grade: '초급',
+      gradeCode: 'JUNIOR',
+      type: '정규직',
+      typeCode: 'FULL_TIME',
+      avatarCode: 'SKY_GLOW',
+      avatarLabel: 'Sky Glow',
+      avatarImageUrl: '',
+      memo: '',
+      joinDate: '2024-01-01',
+      birthDate: '1990-01-01',
+    };
   });
 
   it('employee.write ALL 권한이면 관리자 액션이 보인다', async () => {
     storage.user = JSON.stringify({
       name: '관리자',
       email: 'admin@abms.co.kr',
+      employeeId: 99,
+      departmentId: 10,
       permissions: [
         { code: 'employee.read', scopes: ['ALL'] },
         { code: 'employee.write', scopes: ['ALL'] },
@@ -186,6 +231,8 @@ describe('EmployeeDetailView', () => {
     storage.user = JSON.stringify({
       name: '홍길동',
       email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         { code: 'employee.read', scopes: ['SELF'] },
         { code: 'employee.write', scopes: ['SELF'] },
@@ -204,5 +251,57 @@ describe('EmployeeDetailView', () => {
 
     await selfEditButton?.trigger('click');
     expect(dispatchOpenProfileDialogEventMock).toHaveBeenCalled();
+  });
+
+  it('employee.write OWN_DEPARTMENT 권한이면 같은 부서 직원 관리 액션이 보인다', async () => {
+    employeeData.value = {
+      ...employeeData.value,
+      employeeId: 2,
+      departmentId: 10,
+      email: 'same@abms.co.kr',
+    };
+    storage.user = JSON.stringify({
+      name: '매니저',
+      email: 'manager@abms.co.kr',
+      employeeId: 99,
+      departmentId: 10,
+      permissions: [
+        { code: 'employee.read', scopes: ['OWN_DEPARTMENT'] },
+        { code: 'employee.write', scopes: ['OWN_DEPARTMENT'] },
+      ],
+    });
+    localStorage.setItem('user', storage.user);
+
+    const { wrapper } = await mountDetailView();
+
+    expect(wrapper.text()).toContain('승진');
+    expect(wrapper.text()).toContain('직원 편집');
+    expect(wrapper.text()).toContain('직원 삭제');
+  });
+
+  it('employee.write OWN_DEPARTMENT_TREE 권한이면 하위 부서 직원 관리 액션이 보인다', async () => {
+    employeeData.value = {
+      ...employeeData.value,
+      employeeId: 3,
+      departmentId: 11,
+      email: 'child@abms.co.kr',
+    };
+    storage.user = JSON.stringify({
+      name: '매니저',
+      email: 'manager@abms.co.kr',
+      employeeId: 99,
+      departmentId: 10,
+      permissions: [
+        { code: 'employee.read', scopes: ['OWN_DEPARTMENT_TREE'] },
+        { code: 'employee.write', scopes: ['OWN_DEPARTMENT_TREE'] },
+      ],
+    });
+    localStorage.setItem('user', storage.user);
+
+    const { wrapper } = await mountDetailView();
+
+    expect(wrapper.text()).toContain('승진');
+    expect(wrapper.text()).toContain('직원 편집');
+    expect(wrapper.text()).toContain('직원 삭제');
   });
 });

--- a/frontend/src/features/employee/views/EmployeeDetailView.vue
+++ b/frontend/src/features/employee/views/EmployeeDetailView.vue
@@ -187,7 +187,7 @@ import {
   useTakeLeaveEmployeeMutation,
 } from '@/features/employee/queries/useEmployeeQueries';
 import { employeeKeys, queryClient } from '@/core/query';
-import { canEditOwnProfile, canManageEmployees } from '@/features/employee/permissions';
+import { canEditOwnProfile, canManageEmployee } from '@/features/employee/permissions';
 import { dispatchOpenProfileDialogEvent } from '@/features/auth/profileDialogEvents';
 
 const route = useRoute();
@@ -233,12 +233,21 @@ const employeeInitials = computed(() => {
   const name = employee.value?.name ?? '';
   return name.trim().slice(0, 2).toUpperCase() || '??';
 });
-const canManageCurrentEmployee = computed(() => canManageEmployees());
-const canOpenOwnProfileEdit = computed(() => {
-  if (!employee.value?.email) {
+const employeePermissionContext = computed(() => ({
+  departmentChart: departmentChartQuery.data.value ?? [],
+}));
+const canManageCurrentEmployee = computed(() => {
+  if (!employee.value) {
     return false;
   }
-  return !canManageCurrentEmployee.value && canEditOwnProfile(employee.value.email);
+
+  return canManageEmployee(employee.value, employeePermissionContext.value);
+});
+const canOpenOwnProfileEdit = computed(() => {
+  if (!employee.value) {
+    return false;
+  }
+  return !canManageCurrentEmployee.value && canEditOwnProfile(employee.value);
 });
 
 const isEmployeeUpdateDialogOpen = ref(false);

--- a/frontend/src/features/employee/views/EmployeeListView.spec.ts
+++ b/frontend/src/features/employee/views/EmployeeListView.spec.ts
@@ -35,6 +35,28 @@ const employeesData = ref({
   totalElements: 1,
 });
 
+const departmentChartData = ref([
+  {
+    departmentId: 10,
+    departmentName: '개발팀',
+    departmentCode: 'DEV',
+    departmentType: 'TEAM',
+    departmentLeader: null,
+    employeeCount: 1,
+    children: [
+      {
+        departmentId: 11,
+        departmentName: '하위개발팀',
+        departmentCode: 'DEV-SUB',
+        departmentType: 'TEAM',
+        departmentLeader: null,
+        employeeCount: 1,
+        children: [],
+      },
+    ],
+  },
+]);
+
 const employeeDetailRefetchMock = vi.fn();
 
 const deletionState = {
@@ -85,17 +107,7 @@ vi.mock('@/features/employee/composables', () => ({
 vi.mock('@/features/department/queries/useDepartmentQueries', () => ({
   useDepartmentOrganizationChartQuery: () =>
     createMockQueryState({
-      data: [
-        {
-          departmentId: 10,
-          departmentName: '개발팀',
-          departmentCode: 'DEV',
-          departmentType: 'TEAM',
-          departmentLeader: null,
-          employeeCount: 1,
-          children: [],
-        },
-      ],
+      data: departmentChartData.value,
     }),
 }));
 
@@ -322,6 +334,8 @@ describe('EmployeeListView', () => {
     storage.user = JSON.stringify({
       name: '홍길동',
       email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         { code: 'employee.read', scopes: ['ALL'] },
         { code: 'employee.write', scopes: ['ALL'] },
@@ -419,6 +433,8 @@ describe('EmployeeListView', () => {
     storage.user = JSON.stringify({
       name: '홍길동',
       email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [{ code: 'employee.read', scopes: ['ALL'] }],
     });
     localStorage.setItem('user', storage.user);
@@ -433,6 +449,8 @@ describe('EmployeeListView', () => {
     storage.user = JSON.stringify({
       name: '홍길동',
       email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         { code: 'employee.read', scopes: ['ALL'] },
         { code: 'employee.write', scopes: ['ALL'] },
@@ -453,6 +471,8 @@ describe('EmployeeListView', () => {
     storage.user = JSON.stringify({
       name: '홍길동',
       email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
       permissions: [
         { code: 'employee.read', scopes: ['ALL'] },
         { code: 'employee.write', scopes: ['ALL'] },
@@ -465,5 +485,45 @@ describe('EmployeeListView', () => {
     const uploadButton = wrapper.findAll('button').find((item) => item.text().includes('엑셀 업로드'));
 
     expect(uploadButton).toBeUndefined();
+  });
+
+  it('OWN_DEPARTMENT 권한이면 같은 부서 직원만 액션을 연다', async () => {
+    storage.user = JSON.stringify({
+      name: '홍길동',
+      email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
+      permissions: [
+        { code: 'employee.read', scopes: ['OWN_DEPARTMENT'] },
+        { code: 'employee.write', scopes: ['OWN_DEPARTMENT'] },
+      ],
+    });
+    localStorage.setItem('user', storage.user);
+
+    await mountEmployeeListView();
+
+    expect(tableActionHandlers.canViewEmployee({ employeeId: 2, email: 'same@abms.co.kr', departmentId: 10 })).toBe(true);
+    expect(tableActionHandlers.canEditEmployee({ employeeId: 2, email: 'same@abms.co.kr', departmentId: 10 })).toBe(true);
+    expect(tableActionHandlers.canViewEmployee({ employeeId: 3, email: 'child@abms.co.kr', departmentId: 11 })).toBe(false);
+    expect(tableActionHandlers.canEditEmployee({ employeeId: 3, email: 'child@abms.co.kr', departmentId: 11 })).toBe(false);
+  });
+
+  it('OWN_DEPARTMENT_TREE 권한이면 하위 부서 직원 액션도 연다', async () => {
+    storage.user = JSON.stringify({
+      name: '홍길동',
+      email: 'hong@abms.co.kr',
+      employeeId: 1,
+      departmentId: 10,
+      permissions: [
+        { code: 'employee.read', scopes: ['OWN_DEPARTMENT_TREE'] },
+        { code: 'employee.write', scopes: ['OWN_DEPARTMENT_TREE'] },
+      ],
+    });
+    localStorage.setItem('user', storage.user);
+
+    await mountEmployeeListView();
+
+    expect(tableActionHandlers.canViewEmployee({ employeeId: 3, email: 'child@abms.co.kr', departmentId: 11 })).toBe(true);
+    expect(tableActionHandlers.canEditEmployee({ employeeId: 3, email: 'child@abms.co.kr', departmentId: 11 })).toBe(true);
   });
 });

--- a/frontend/src/features/employee/views/EmployeeListView.vue
+++ b/frontend/src/features/employee/views/EmployeeListView.vue
@@ -263,6 +263,7 @@ import { employeeKeys, queryClient } from '@/core/query';
 import {
   canDownloadEmployeeExcel,
   canEditOwnProfile,
+  canManageEmployee,
   canManageEmployees,
   canUploadEmployeeExcel,
   canViewEmployeeDetail,
@@ -304,6 +305,9 @@ const selectedRowCount = computed(() => Object.keys(rowSelection.value).length);
 const canCreateEmployees = computed(() => canManageEmployees());
 const canUploadEmployees = computed(() => canUploadEmployeeExcel());
 const canDownloadEmployees = computed(() => canDownloadEmployeeExcel());
+const employeePermissionContext = computed(() => ({
+  departmentChart: departmentChartQuery.data.value ?? [],
+}));
 
 // 테이블 컬럼 정의 (EmployeeTableColumns.ts로 분리됨)
 const columns = createEmployeeTableColumns({
@@ -312,11 +316,14 @@ const columns = createEmployeeTableColumns({
   onCopyEmail: handleCopyEmail,
   onDeleteEmployee: handleDeleteEmployee,
   onNavigateToDepartment: navigateToDepartment,
-  canViewEmployee: (employee) => canViewEmployeeDetail(employee.email),
-  canEditEmployee: (employee) => canManageEmployees() || canEditOwnProfile(employee.email),
-  canDeleteEmployee: () => canManageEmployees(),
+  canViewEmployee: (employee) => canViewEmployeeDetail(employee, employeePermissionContext.value),
+  canEditEmployee: (employee) =>
+    canManageEmployee(employee, employeePermissionContext.value) || canEditOwnProfile(employee),
+  canDeleteEmployee: (employee) => canManageEmployee(employee, employeePermissionContext.value),
   getEditActionLabel: (employee) =>
-    !canManageEmployees() && canEditOwnProfile(employee.email) ? '내 정보 수정' : '직원 편집',
+    !canManageEmployee(employee, employeePermissionContext.value) && canEditOwnProfile(employee)
+      ? '내 정보 수정'
+      : '직원 편집',
 });
 
 // URL 쿼리 동기화 Composable 초기화
@@ -575,10 +582,10 @@ async function handleEmployeeUpdated() {
 }
 
 async function handleEditEmployee(row: EmployeeListItem) {
-  if (!(canManageEmployees() || canEditOwnProfile(row.email))) {
+  if (!(canManageEmployee(row, employeePermissionContext.value) || canEditOwnProfile(row))) {
     return;
   }
-  if (!canManageEmployees() && canEditOwnProfile(row.email)) {
+  if (!canManageEmployee(row, employeePermissionContext.value) && canEditOwnProfile(row)) {
     dispatchOpenProfileDialogEvent({ openSelfProfileEditor: true });
     return;
   }
@@ -621,14 +628,14 @@ async function handleCopyEmail(row: EmployeeListItem) {
 }
 
 function handleDeleteEmployee(row: EmployeeListItem) {
-  if (!canManageEmployees()) {
+  if (!canManageEmployee(row, employeePermissionContext.value)) {
     return;
   }
   deletion.open(row.employeeId, row.name);
 }
 
 function handleViewEmployee(row: EmployeeListItem) {
-  if (!canViewEmployeeDetail(row.email)) {
+  if (!canViewEmployeeDetail(row, employeePermissionContext.value)) {
     return;
   }
   router.push({ name: 'employee-detail', params: { employeeId: row.employeeId } }).catch(() => {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -9,11 +9,13 @@ import '@/assets/fonts.css';
 import { configureContainer } from '@/core/di/container';
 import { initializeTheme } from '@/core/composables';
 import { registerAuthHttpErrorHandler } from '@/features/auth/registerAuthHttpErrorHandler';
+import { initializeSessionSync } from '@/features/auth/session';
 import { queryClient } from '@/core/query';
 
 configureContainer();
 initializeTheme();
 registerAuthHttpErrorHandler(router);
+initializeSessionSync();
 
 const app = createApp(App);
 app.use(createPinia());


### PR DESCRIPTION
## 변경 요약

- 직원 엑셀 다운로드/업로드 권한을 employee.read, employee.write에서 분리하고, 프런트에서 OWN_DEPARTMENT / OWN_DEPARTMENT_TREE scope를 실제 부서 범위
기준으로 반영했습니다.
- 로그인 첫 시도 실패를 막기 위해 로그인 직전 CSRF 초기화를 보장했고, 현재 사용자 부서 변경 시 stale 세션이 오래 남지 않도록 auth/me 재동기화 흐름을
보강했습니다.
- 조직도 캐시 테스트는 시간 비교 기반 플래키 검증을 제거하고 실제 캐시 재사용 검증으로 안정화했습니다.

## 관련 이슈 (필수)

- Closes #69
- Refs #70
- Refs #71

## 핵심 검증 (필수)

- [x] 로컬에서 핵심 시나리오를 검증했다.
- 검증 내용 요약:
    - ./gradlew clean build 통과
    - ./gradlew :abms-api-boot:test --tests 'kr.co.abacus.abms.adapter.api.auth.AuthApiTest' --tests
'kr.co.abacus.abms.application.auth.AuthFinderTest' 통과
    - cd frontend && npm run lint 통과
    - cd frontend && npm run typecheck 통과
    - cd frontend && npm run test:e2e 통과
    - 프런트 단위 테스트에서 OWN_DEPARTMENT, OWN_DEPARTMENT_TREE 기준 액션 노출 검증 통과

## 증빙 자료 (조건부 필수)

- [x] UI 변경 없음 (해당 시 아래 생략 가능)
- [ ] UI 변경 있음: Before/After 캡처 첨부
- [ ] 동작 흐름 확인 필요: 짧은 영상(GIF/MP4) 첨부
- 첨부 링크/설명:
    - 없음

## 영향도 (필수)

- API 변경: [x] 있음 [ ] 없음
- DB 스키마/데이터 마이그레이션: [ ] 있음 [x] 없음
- ENV 변수 추가/변경: [ ] 있음 [x] 없음

## 리뷰/머지 체크

- [ ] 팀원 1명 승인 완료
- [ ] CI 체크 통과

## Hotfix 예외

- [ ] 이 PR은 hotfix/* 이다. (체크 시 셀프 머지 허용)
- [ ] 사후 리뷰 이슈를 생성했고 24시간 내 리뷰한다.