### PR TITLE
비밀번호 찾기/재설정 기능 추가

### DIFF
--- a/abms-adapter-batch/src/main/java/kr/co/abacus/abms/adapter/batch/RevenueMonthlySummaryBatchConfig.java
+++ b/abms-adapter-batch/src/main/java/kr/co/abacus/abms/adapter/batch/RevenueMonthlySummaryBatchConfig.java
@@ -16,6 +16,8 @@ import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.Step;
 import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
 import org.springframework.batch.infrastructure.item.ItemProcessor;
 import org.springframework.batch.infrastructure.item.ItemWriter;
 import org.springframework.batch.infrastructure.item.database.JpaPagingItemReader;
@@ -66,8 +68,31 @@ public class RevenueMonthlySummaryBatchConfig {
     public Job revenueMonthlySummaryJob() {
         return new JobBuilder("revenueMonthlySummaryJob", jobRepository)
             .listener(batchObservabilityListener)
-            .start(revenueMonthlySummaryStep())
+            .start(deleteMonthlyRevenueSummaryStep())
+            .next(revenueMonthlySummaryStep())
             .build();
+    }
+
+    @Bean
+    public Step deleteMonthlyRevenueSummaryStep() {
+        return new StepBuilder("deleteMonthlyRevenueSummaryStep", jobRepository)
+            .tasklet(deleteMonthlyRevenueSummaryTasklet(null), transactionManager)
+            .build();
+    }
+
+    @Bean
+    @StepScope
+    public Tasklet deleteMonthlyRevenueSummaryTasklet(
+        @Value("#{jobParameters['targetDate'] ?: null}") LocalDate targetDate
+    ) {
+        return (contribution, chunkContext) -> {
+            LocalDate executeDate = (targetDate != null) ? targetDate : LocalDate.now().minusDays(1);
+            YearMonth yearMonth = YearMonth.from(executeDate);
+
+            log.info("매출 요약 데이터 삭제 시작: {}", yearMonth);
+            summaryRepository.deleteBySummaryDateBetween(yearMonth.atDay(1), yearMonth.atEndOfMonth());
+            return RepeatStatus.FINISHED;
+        };
     }
 
     @Bean
@@ -162,7 +187,7 @@ public class RevenueMonthlySummaryBatchConfig {
                    leadDepartment.getId(),
                    leadDepartment.getCode(),
                    leadDepartment.getName(),
-                   executeDate,
+                   executeDate, // monthStart 대신 다시 executeDate 사용
                    totalRevenue,
                    totalCost,
                    totalProfit

--- a/abms-adapter-integration/src/main/java/kr/co/abacus/abms/adapter/infrastructure/mail/SmtpPasswordResetLinkSender.java
+++ b/abms-adapter-integration/src/main/java/kr/co/abacus/abms/adapter/infrastructure/mail/SmtpPasswordResetLinkSender.java
@@ -1,0 +1,139 @@
+package kr.co.abacus.abms.adapter.infrastructure.mail;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetLinkSender;
+import kr.co.abacus.abms.domain.shared.Email;
+
+@Profile("!test")
+@Component
+public class SmtpPasswordResetLinkSender implements PasswordResetLinkSender {
+
+    private static final DateTimeFormatter EXPIRES_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final String LOGO_CONTENT_ID = "abmsLogo";
+
+    private final JavaMailSender mailSender;
+    private final String fromAddress;
+    private final String subject;
+    private final String confirmUrl;
+    private final String logoPath;
+    private final String logoUrl;
+    private final MeterRegistry meterRegistry;
+
+    public SmtpPasswordResetLinkSender(
+            JavaMailSender mailSender,
+            @Value("${app.auth.password-reset-mail.from}") String fromAddress,
+            @Value("${app.auth.password-reset-mail.subject}") String subject,
+            @Value("${app.auth.password-reset-mail.confirm-url}") String confirmUrl,
+            @Value("${app.auth.password-reset-mail.logo-path:mail/main_logo.png}") String logoPath,
+            @Value("${app.auth.password-reset-mail.logo-url:}") String logoUrl,
+            MeterRegistry meterRegistry
+    ) {
+        this.mailSender = mailSender;
+        this.fromAddress = fromAddress;
+        this.subject = subject;
+        this.confirmUrl = confirmUrl;
+        this.logoPath = logoPath;
+        this.logoUrl = logoUrl;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void sendPasswordResetLink(Email email, String token, LocalDateTime expiresAt) {
+        String link = UriComponentsBuilder.fromUriString(confirmUrl)
+                .queryParam("token", token)
+                .build(true)
+                .toUriString();
+        long startedAt = System.nanoTime();
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(
+                    message,
+                    MimeMessageHelper.MULTIPART_MODE_RELATED,
+                    StandardCharsets.UTF_8.name()
+            );
+            helper.setTo(email.address());
+            helper.setFrom(fromAddress);
+            helper.setSubject(subject);
+            helper.setText(buildPlainBody(link, expiresAt), buildHtmlBody(link, expiresAt));
+            if (!StringUtils.hasText(logoUrl)) {
+                helper.addInline(LOGO_CONTENT_ID, new ClassPathResource(logoPath), "image/png");
+            }
+            mailSender.send(message);
+            recordMail("success", startedAt);
+        } catch (MessagingException exception) {
+            recordMail("failure", startedAt);
+            throw new IllegalStateException("비밀번호 재설정 메일 생성 중 오류가 발생했습니다.", exception);
+        } catch (RuntimeException exception) {
+            recordMail("failure", startedAt);
+            throw exception;
+        }
+    }
+
+    private void recordMail(String outcome, long startedAt) {
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000L;
+        meterRegistry.counter("abms.mail.send.total", "type", "password_reset", "outcome", outcome).increment();
+        meterRegistry.timer("abms.mail.send.duration", "type", "password_reset", "outcome", outcome)
+                .record(durationMs, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    private String buildHtmlBody(String link, LocalDateTime expiresAt) {
+        String logoSource = StringUtils.hasText(logoUrl) ? logoUrl : "cid:" + LOGO_CONTENT_ID;
+        return """
+                <div style="font-family: Arial, sans-serif; padding: 20px; max-width: 520px; margin: 0 auto; color: #333;">
+                  <div style="margin-bottom: 20px;">
+                    <img src="%s" alt="ABMS logo" style="height: 38px;" />
+                  </div>
+                  <h1 style="font-size: 24px; margin: 0 0 16px;">비밀번호 재설정 안내</h1>
+                  <p style="font-size: 15px; color: #555; margin: 0 0 8px;">안녕하세요,</p>
+                  <p style="font-size: 15px; color: #555; margin: 0 0 20px;">
+                    아래 버튼을 눌러 ABMS 계정의 비밀번호를 재설정해 주세요.
+                  </p>
+                  <a href="%s" style="display: inline-block; background-color: #EB6129; color: #fff; padding: 12px 24px; font-size: 15px; text-decoration: none; border-radius: 6px; margin: 0 0 20px;">
+                    비밀번호 재설정하기
+                  </a>
+                  <p style="font-size: 12px; color: #777; margin: 0 0 4px;">
+                    버튼이 동작하지 않으면 아래 링크를 브라우저에 붙여넣어 주세요.
+                  </p>
+                  <p style="font-size: 12px; color: #EB6129; word-break: break-word; margin: 0 0 18px;">
+                    %s
+                  </p>
+                  <p style="font-size: 12px; color: #777; margin: 0 0 4px;">
+                    링크 만료 시각: %s
+                  </p>
+                  <p style="font-size: 11px; color: #999; margin: 16px 0 0;">
+                    본인이 요청하지 않았다면 이 메일을 무시해 주세요.
+                  </p>
+                </div>
+                """
+                .formatted(logoSource, link, link, expiresAt.format(EXPIRES_AT_FORMATTER));
+    }
+
+    private String buildPlainBody(String link, LocalDateTime expiresAt) {
+        return """
+                ABMS 비밀번호 재설정 안내
+
+                아래 링크를 브라우저에서 열어 비밀번호를 재설정해 주세요.
+                %s
+
+                링크 만료 시각: %s
+                본인이 요청하지 않았다면 이 메일을 무시해 주세요.
+                """.formatted(link, expiresAt.format(EXPIRES_AT_FORMATTER));
+    }
+}

--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/auth/PasswordResetTokenRepository.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/auth/PasswordResetTokenRepository.java
@@ -1,0 +1,10 @@
+package kr.co.abacus.abms.adapter.infrastructure.auth;
+
+import org.springframework.data.repository.Repository;
+
+import kr.co.abacus.abms.domain.auth.PasswordResetToken;
+
+public interface PasswordResetTokenRepository
+        extends Repository<PasswordResetToken, Long>,
+        kr.co.abacus.abms.application.auth.outbound.PasswordResetTokenRepository {
+}

--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/summary/MonthlyRevenueSummaryRepository.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/summary/MonthlyRevenueSummaryRepository.java
@@ -1,10 +1,20 @@
 package kr.co.abacus.abms.adapter.infrastructure.summary;
 
+import java.time.LocalDate;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummary;
 
 public interface MonthlyRevenueSummaryRepository
         extends JpaRepository<MonthlyRevenueSummary, Long>,
         kr.co.abacus.abms.application.summary.outbound.MonthlyRevenueSummaryRepository {
+
+    @Override
+    @Modifying
+    @Query("DELETE FROM MonthlyRevenueSummary s WHERE s.summaryDate >= :start AND s.summaryDate <= :end")
+    void deleteBySummaryDateBetween(@Param("start") LocalDate start, @Param("end") LocalDate end);
 }

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/AuthApi.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/AuthApi.java
@@ -20,6 +20,8 @@ import kr.co.abacus.abms.adapter.api.auth.dto.AuthMeResponse;
 import kr.co.abacus.abms.adapter.security.CurrentActorResolver;
 import kr.co.abacus.abms.adapter.api.auth.dto.ChangePasswordRequest;
 import kr.co.abacus.abms.adapter.api.auth.dto.LoginRequest;
+import kr.co.abacus.abms.adapter.api.auth.dto.PasswordResetConfirmRequest;
+import kr.co.abacus.abms.adapter.api.auth.dto.PasswordResetRequest;
 import kr.co.abacus.abms.adapter.api.auth.dto.RegistrationConfirmRequest;
 import kr.co.abacus.abms.adapter.api.auth.dto.RegistrationRequest;
 import kr.co.abacus.abms.application.auth.inbound.AuthFinder;
@@ -64,6 +66,16 @@ public class AuthApi {
     @PostMapping("/api/auth/registration-confirmations")
     public void confirmRegistration(@RequestBody @Valid RegistrationConfirmRequest request) {
         authManager.confirmRegistration(request.toCommand());
+    }
+
+    @PostMapping("/api/auth/password-reset-requests")
+    public void requestPasswordReset(@RequestBody @Valid PasswordResetRequest request) {
+        authManager.requestPasswordReset(request.toCommand());
+    }
+
+    @PostMapping("/api/auth/password-reset-confirmations")
+    public void confirmPasswordReset(@RequestBody @Valid PasswordResetConfirmRequest request) {
+        authManager.confirmPasswordReset(request.toCommand());
     }
 
     @GetMapping("/api/auth/me")

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/PasswordResetConfirmRequest.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/PasswordResetConfirmRequest.java
@@ -1,0 +1,24 @@
+package kr.co.abacus.abms.adapter.api.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import kr.co.abacus.abms.application.auth.dto.PasswordResetConfirmCommand;
+
+public record PasswordResetConfirmRequest(
+        @NotBlank String token,
+        @NotBlank
+        @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다."
+        )
+        String password
+) {
+
+    public PasswordResetConfirmCommand toCommand() {
+        return new PasswordResetConfirmCommand(token, password);
+    }
+
+}

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/PasswordResetRequest.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/auth/dto/PasswordResetRequest.java
@@ -1,0 +1,20 @@
+package kr.co.abacus.abms.adapter.api.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+import kr.co.abacus.abms.application.auth.dto.PasswordResetRequestCommand;
+
+public record PasswordResetRequest(
+        @NotBlank
+        @Email
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@iabacus\\.co\\.kr$", message = "회사 이메일(@iabacus.co.kr)만 사용할 수 있습니다.")
+        String email
+) {
+
+    public PasswordResetRequestCommand toCommand() {
+        return new PasswordResetRequestCommand(email);
+    }
+
+}

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/common/ApiControllerAdvice.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/common/ApiControllerAdvice.java
@@ -18,6 +18,7 @@ import kr.co.abacus.abms.domain.account.AccountAlreadyExistsException;
 import kr.co.abacus.abms.domain.account.InvalidCurrentPasswordException;
 import kr.co.abacus.abms.domain.account.AccountNotFoundException;
 import kr.co.abacus.abms.domain.account.SamePasswordException;
+import kr.co.abacus.abms.domain.auth.InvalidPasswordResetTokenException;
 import kr.co.abacus.abms.domain.auth.InvalidRegistrationTokenException;
 import kr.co.abacus.abms.domain.department.DepartmentNotFoundException;
 import kr.co.abacus.abms.domain.employee.DuplicateEmailException;
@@ -55,6 +56,7 @@ public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
             InvalidEmployeeStatusException.class,
             AccountAlreadyExistsException.class,
             InvalidRegistrationTokenException.class,
+            InvalidPasswordResetTokenException.class,
             InvalidCurrentPasswordException.class,
             SamePasswordException.class,
             DuplicatePermissionGroupNameException.class,

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/security/config/SecurityConfig.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/security/config/SecurityConfig.java
@@ -90,6 +90,8 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/registration-requests",
                                 "/api/auth/registration-confirmations",
+                                "/api/auth/password-reset-requests",
+                                "/api/auth/password-reset-confirmations",
                                 "/api/auth/logout",
                                 "/actuator/health",
                                 "/actuator/info",

--- a/abms-api-boot/src/docs/asciidoc/index.adoc
+++ b/abms-api-boot/src/docs/asciidoc/index.adoc
@@ -85,6 +85,34 @@ include::{snippets}/auth/change-password/http-request.adoc[]
 .HTTP response
 include::{snippets}/auth/change-password/http-response.adoc[]
 
+=== Request Password Reset
+
+사내 이메일로 비밀번호 재설정 요청을 시작합니다.
+계정 존재 여부가 노출되지 않도록 요청 결과는 동일하게 성공 응답을 반환합니다.
+
+.Request body
+include::{snippets}/auth/password-reset-request/request-body.adoc[]
+
+.HTTP request
+include::{snippets}/auth/password-reset-request/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/auth/password-reset-request/http-response.adoc[]
+
+=== Confirm Password Reset
+
+재설정 토큰과 새 비밀번호로 계정 비밀번호를 재설정합니다.
+새 비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다.
+
+.Request body
+include::{snippets}/auth/password-reset-confirmation/request-body.adoc[]
+
+.HTTP request
+include::{snippets}/auth/password-reset-confirmation/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/auth/password-reset-confirmation/http-response.adoc[]
+
 === Logout
 
 현재 세션을 종료합니다.

--- a/abms-api-boot/src/main/resources/application-dev.yml
+++ b/abms-api-boot/src/main/resources/application-dev.yml
@@ -24,6 +24,10 @@ app:
       from: ${APP_AUTH_REGISTRATION_MAIL_FROM:no-reply@iabacus.co.kr}
       subject: ${APP_AUTH_REGISTRATION_MAIL_SUBJECT:[ABMS] 회원가입 링크 안내}
       confirm-url: ${APP_AUTH_REGISTRATION_MAIL_CONFIRM_URL:http://localhost:5173/auths/registration-confirm}
+    password-reset-mail:
+      from: ${APP_AUTH_PASSWORD_RESET_MAIL_FROM:no-reply@iabacus.co.kr}
+      subject: ${APP_AUTH_PASSWORD_RESET_MAIL_SUBJECT:[ABMS] 비밀번호 재설정 안내}
+      confirm-url: ${APP_AUTH_PASSWORD_RESET_MAIL_CONFIRM_URL:http://localhost:5173/auths/password-reset-confirm}
 
 logging:
   level:

--- a/abms-api-boot/src/main/resources/application-local.yml
+++ b/abms-api-boot/src/main/resources/application-local.yml
@@ -25,6 +25,10 @@ app:
       from: ${APP_AUTH_REGISTRATION_MAIL_FROM:no-reply@iabacus.co.kr}
       subject: ${APP_AUTH_REGISTRATION_MAIL_SUBJECT:[ABMS] 회원가입 링크 안내}
       confirm-url: ${APP_AUTH_REGISTRATION_MAIL_CONFIRM_URL:http://localhost:5173/auths/registration-confirm}
+    password-reset-mail:
+      from: ${APP_AUTH_PASSWORD_RESET_MAIL_FROM:no-reply@iabacus.co.kr}
+      subject: ${APP_AUTH_PASSWORD_RESET_MAIL_SUBJECT:[ABMS] 비밀번호 재설정 안내}
+      confirm-url: ${APP_AUTH_PASSWORD_RESET_MAIL_CONFIRM_URL:http://localhost:5173/auths/password-reset-confirm}
 
 logging:
   level:

--- a/abms-api-boot/src/main/resources/application.yml
+++ b/abms-api-boot/src/main/resources/application.yml
@@ -37,6 +37,10 @@ app:
       from: ${APP_AUTH_REGISTRATION_MAIL_FROM}
       subject: ${APP_AUTH_REGISTRATION_MAIL_SUBJECT}
       confirm-url: ${APP_AUTH_REGISTRATION_MAIL_CONFIRM_URL}
+    password-reset-mail:
+      from: ${APP_AUTH_PASSWORD_RESET_MAIL_FROM}
+      subject: ${APP_AUTH_PASSWORD_RESET_MAIL_SUBJECT}
+      confirm-url: ${APP_AUTH_PASSWORD_RESET_MAIL_CONFIRM_URL}
   observability:
     environment: ${APP_ENVIRONMENT:${spring.profiles.active:local}}
     log-file-name: ${APP_LOG_FILE_NAME:logs/abms-api.log}

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/auth/AuthApiTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import kr.co.abacus.abms.adapter.security.CustomUserDetails;
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetTokenRepository;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
 import kr.co.abacus.abms.application.permission.outbound.AccountGroupAssignmentRepository;
@@ -33,6 +34,7 @@ import kr.co.abacus.abms.application.permission.outbound.GroupPermissionGrantRep
 import kr.co.abacus.abms.application.permission.outbound.PermissionGroupRepository;
 import kr.co.abacus.abms.application.permission.outbound.PermissionRepository;
 import kr.co.abacus.abms.domain.account.Account;
+import kr.co.abacus.abms.domain.auth.PasswordResetToken;
 import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
 import kr.co.abacus.abms.domain.auth.RegistrationToken;
 import kr.co.abacus.abms.domain.employee.Employee;
@@ -65,6 +67,9 @@ class AuthApiTest extends ApiIntegrationTestBase {
 
     @Autowired
     private RegistrationTokenRepository registrationTokenRepository;
+
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
 
     @Autowired
     private DefaultPermissionGroupRepository defaultPermissionGroupRepository;
@@ -498,6 +503,94 @@ class AuthApiTest extends ApiIntegrationTestBase {
                         .content(toJson(Map.of(
                                 "token", registrationToken.getToken(),
                                 "password", "password1234"
+                        ))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 요청 시 항상 성공 응답을 반환하고 가입 계정이면 토큰을 생성한다")
+    void should_requestPasswordReset() throws Exception {
+        String resetEmail = "reset-user@iabacus.co.kr";
+        Employee employee = employeeRepository.save(createEmployee(resetEmail, "재설정요청직원"));
+        accountRepository.save(Account.create(employee.getIdOrThrow(), resetEmail, passwordEncoder.encode(PASSWORD)));
+        flushAndClear();
+
+        mockMvc.perform(post("/api/auth/password-reset-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("email", resetEmail))))
+                .andDo(document("auth/password-reset-request",
+                        requestFields(
+                                fieldWithPath("email").description("비밀번호 재설정을 요청할 회사 이메일")
+                        )))
+                .andExpect(status().isOk());
+
+        PasswordResetToken passwordResetToken = passwordResetTokenRepository
+                .findFirstByEmailOrderByCreatedAtDesc(new Email(resetEmail))
+                .orElseThrow();
+
+        assertThat(passwordResetToken.getToken()).isNotBlank();
+
+        mockMvc.perform(post("/api/auth/password-reset-requests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("email", "missing@iabacus.co.kr"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 토큰으로 새 비밀번호를 설정할 수 있다")
+    void should_confirmPasswordReset() throws Exception {
+        Account account = accountRepository.findByUsername(new Email(USERNAME)).orElseThrow();
+        passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                USERNAME,
+                "api-reset-token",
+                LocalDateTime.now().plusMinutes(30)
+        ));
+        flushAndClear();
+
+        mockMvc.perform(post("/api/auth/password-reset-confirmations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "token", "api-reset-token",
+                                "password", "ResetPassword123!"
+                        ))))
+                .andDo(document("auth/password-reset-confirmation",
+                        requestFields(
+                                fieldWithPath("token").description("비밀번호 재설정 토큰"),
+                                fieldWithPath("password").description("새 비밀번호")
+                        )))
+                .andExpect(status().isOk());
+        flushAndClear();
+
+        Account changed = accountRepository.findByUsername(new Email(USERNAME)).orElseThrow();
+        assertThat(passwordEncoder.matches("ResetPassword123!", changed.getPassword())).isTrue();
+        assertThat(passwordEncoder.matches(PASSWORD, changed.getPassword())).isFalse();
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "username", USERNAME,
+                                "password", "ResetPassword123!"
+                        ))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "username", USERNAME,
+                                "password", PASSWORD
+                        ))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 비밀번호 재설정 토큰이면 400을 반환한다")
+    void should_returnBadRequest_whenPasswordResetTokenIsInvalid() throws Exception {
+        mockMvc.perform(post("/api/auth/password-reset-confirmations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of(
+                                "token", "invalid-reset-token",
+                                "password", "ResetPassword123!"
                         ))))
                 .andExpect(status().isBadRequest());
     }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/dashboard/DashboardApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/dashboard/DashboardApiTest.java
@@ -94,7 +94,6 @@ class DashboardApiTest extends ApiIntegrationTestBase {
         Department department = departmentRepository.save(Department.create("TEAM-DASHBOARD-MONTHLY", "대시보드 월별팀", DepartmentType.TEAM, null, null));
 
         monthlyRevenueSummaryRepository.saveAll(List.of(
-                createMonthlyRevenueSummary(department, 101L, "MONTH-01", "1월 프로젝트", LocalDate.of(2026, 1, 5), 120_000_000L, 80_000_000L, 40_000_000L),
                 createMonthlyRevenueSummary(department, 101L, "MONTH-01", "1월 프로젝트", LocalDate.of(2026, 1, 31), 140_000_000L, 90_000_000L, 50_000_000L),
                 createMonthlyRevenueSummary(department, 102L, "MONTH-02", "2월 프로젝트", LocalDate.of(2026, 2, 28), 90_000_000L, 60_000_000L, 30_000_000L)
         ));
@@ -184,7 +183,6 @@ class DashboardApiTest extends ApiIntegrationTestBase {
         Department beta = departmentRepository.save(Department.create("TEAM-DASH-BETA", "베타팀", DepartmentType.TEAM, null, null));
 
         monthlyRevenueSummaryRepository.saveAll(List.of(
-                createMonthlyRevenueSummary(alpha, 101L, "ALPHA-01", "알파 프로젝트 1", LocalDate.of(2026, 1, 10), 120_000_000L, 80_000_000L, 40_000_000L),
                 createMonthlyRevenueSummary(alpha, 101L, "ALPHA-01", "알파 프로젝트 1", LocalDate.of(2026, 1, 31), 140_000_000L, 90_000_000L, 50_000_000L),
                 createMonthlyRevenueSummary(alpha, 102L, "ALPHA-02", "알파 프로젝트 2", LocalDate.of(2026, 2, 25), 80_000_000L, 55_000_000L, 25_000_000L),
                 createMonthlyRevenueSummary(beta, 201L, "BETA-01", "베타 프로젝트 1", LocalDate.of(2026, 3, 28), 90_000_000L, 60_000_000L, 30_000_000L),

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/AuthManagerTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/application/auth/AuthManagerTest.java
@@ -17,11 +17,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.mockito.ArgumentCaptor;
 
 import kr.co.abacus.abms.application.auth.dto.ChangePasswordCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetConfirmCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetRequestCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationConfirmCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationRequestCommand;
 import kr.co.abacus.abms.application.auth.inbound.AuthManager;
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetLinkSender;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetTokenRepository;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationLinkSender;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
@@ -31,6 +35,8 @@ import kr.co.abacus.abms.domain.account.AccountAlreadyExistsException;
 import kr.co.abacus.abms.domain.account.InvalidCurrentPasswordException;
 import kr.co.abacus.abms.domain.account.SamePasswordException;
 import kr.co.abacus.abms.domain.accountgroupassignment.AccountGroupAssignment;
+import kr.co.abacus.abms.domain.auth.InvalidPasswordResetTokenException;
+import kr.co.abacus.abms.domain.auth.PasswordResetToken;
 import kr.co.abacus.abms.domain.auth.InvalidRegistrationTokenException;
 import kr.co.abacus.abms.domain.auth.RegistrationToken;
 import kr.co.abacus.abms.domain.employee.Employee;
@@ -63,7 +69,13 @@ class AuthManagerTest extends IntegrationTestBase {
     private RegistrationTokenRepository registrationTokenRepository;
 
     @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+
+    @Autowired
     private RegistrationLinkSender registrationLinkSender;
+
+    @Autowired
+    private PasswordResetLinkSender passwordResetLinkSender;
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -77,6 +89,7 @@ class AuthManagerTest extends IntegrationTestBase {
     @BeforeEach
     void resetRegistrationSender() {
         reset(registrationLinkSender);
+        reset(passwordResetLinkSender);
     }
 
     @Test
@@ -239,6 +252,107 @@ class AuthManagerTest extends IntegrationTestBase {
 
         assertThatThrownBy(() -> authManager.changePassword(
                 new ChangePasswordCommand(EMAIL, PASSWORD, PASSWORD)))
+                .isInstanceOf(SamePasswordException.class)
+                .hasMessage("새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 요청 시 토큰을 발급하고 메일을 발송한다")
+    void requestPasswordReset() {
+        Employee employee = employeeRepository.save(createEmployee(EMAIL, "비밀번호찾기직원"));
+        Account account = accountRepository.save(Account.create(employee.getIdOrThrow(), EMAIL, passwordEncoder.encode(PASSWORD)));
+        PasswordResetToken oldToken = passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                EMAIL,
+                "old-reset-token",
+                LocalDateTime.now().plusMinutes(10)
+        ));
+        flushAndClear();
+
+        authManager.requestPasswordReset(new PasswordResetRequestCommand(EMAIL));
+        flushAndClear();
+
+        PasswordResetToken latestToken = passwordResetTokenRepository.findFirstByEmailOrderByCreatedAtDesc(new Email(EMAIL))
+                .orElseThrow();
+
+        assertThat(latestToken.getToken()).isNotEqualTo("old-reset-token");
+        assertThat(latestToken.getAccountId()).isEqualTo(account.getId());
+        assertThat(latestToken.getExpiresAt()).isAfter(LocalDateTime.now().plusMinutes(29));
+        assertThat(passwordResetTokenRepository.findByToken(oldToken.getToken())).isEmpty();
+        verify(passwordResetLinkSender).sendPasswordResetLink(
+                eq(new Email(EMAIL)),
+                eq(latestToken.getToken()),
+                any(LocalDateTime.class)
+        );
+    }
+
+    @Test
+    @DisplayName("가입되지 않은 이메일로 비밀번호 재설정을 요청해도 성공 처리하고 토큰을 만들지 않는다")
+    void requestPasswordReset_unknownEmail() {
+        authManager.requestPasswordReset(new PasswordResetRequestCommand("missing@iabacus.co.kr"));
+        flushAndClear();
+
+        assertThat(passwordResetTokenRepository.findFirstByEmailOrderByCreatedAtDesc(new Email("missing@iabacus.co.kr")))
+                .isEmpty();
+        verifyNoInteractions(passwordResetLinkSender);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰으로 비밀번호를 재설정한다")
+    void confirmPasswordReset() {
+        Employee employee = employeeRepository.save(createEmployee(EMAIL, "비밀번호재설정직원"));
+        Account account = accountRepository.save(Account.create(employee.getIdOrThrow(), EMAIL, passwordEncoder.encode(PASSWORD)));
+        passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                EMAIL,
+                "reset-token",
+                LocalDateTime.now().plusMinutes(30)
+        ));
+        flushAndClear();
+
+        authManager.confirmPasswordReset(new PasswordResetConfirmCommand("reset-token", "ResetPassword123!"));
+        flushAndClear();
+
+        Account changed = accountRepository.findByUsername(new Email(EMAIL)).orElseThrow();
+        assertThat(passwordEncoder.matches("ResetPassword123!", changed.getPassword())).isTrue();
+        assertThat(passwordEncoder.matches(PASSWORD, changed.getPassword())).isFalse();
+        assertThat(passwordResetTokenRepository.findByToken("reset-token")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰으로 비밀번호 재설정하면 예외가 발생한다")
+    void confirmPasswordReset_expiredToken() {
+        Employee employee = employeeRepository.save(createEmployee(EMAIL, "만료재설정직원"));
+        Account account = accountRepository.save(Account.create(employee.getIdOrThrow(), EMAIL, passwordEncoder.encode(PASSWORD)));
+        passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                EMAIL,
+                "expired-reset-token",
+                LocalDateTime.now().minusMinutes(1)
+        ));
+        flushAndClear();
+
+        assertThatThrownBy(() -> authManager.confirmPasswordReset(
+                new PasswordResetConfirmCommand("expired-reset-token", "ResetPassword123!")))
+                .isInstanceOf(InvalidPasswordResetTokenException.class)
+                .hasMessage("만료된 비밀번호 재설정 토큰입니다.");
+    }
+
+    @Test
+    @DisplayName("현재 비밀번호와 같은 비밀번호로 재설정하면 실패한다")
+    void confirmPasswordReset_samePassword() {
+        Employee employee = employeeRepository.save(createEmployee(EMAIL, "동일재설정직원"));
+        Account account = accountRepository.save(Account.create(employee.getIdOrThrow(), EMAIL, passwordEncoder.encode(PASSWORD)));
+        passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                EMAIL,
+                "same-password-reset-token",
+                LocalDateTime.now().plusMinutes(30)
+        ));
+        flushAndClear();
+
+        assertThatThrownBy(() -> authManager.confirmPasswordReset(
+                new PasswordResetConfirmCommand("same-password-reset-token", PASSWORD)))
                 .isInstanceOf(SamePasswordException.class)
                 .hasMessage("새 비밀번호는 현재 비밀번호와 달라야 합니다.");
     }

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/support/TestMailMockConfig.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/support/TestMailMockConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetLinkSender;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationLinkSender;
 
 @Profile("test")
@@ -15,6 +16,11 @@ public class TestMailMockConfig {
     @Bean
     RegistrationLinkSender registrationLinkSender() {
         return mock(RegistrationLinkSender.class);
+    }
+
+    @Bean
+    PasswordResetLinkSender passwordResetLinkSender() {
+        return mock(PasswordResetLinkSender.class);
     }
 
 }

--- a/abms-api-boot/src/test/resources/application-test.yml
+++ b/abms-api-boot/src/test/resources/application-test.yml
@@ -26,6 +26,10 @@ app:
       from: no-reply@iabacus.co.kr
       subject: "[ABMS] 회원가입 링크 안내"
       confirm-url: http://localhost:5173/auths/registration-confirm
+    password-reset-mail:
+      from: no-reply@iabacus.co.kr
+      subject: "[ABMS] 비밀번호 재설정 안내"
+      confirm-url: http://localhost:5173/auths/password-reset-confirm
   observability:
     health:
       mail:

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthCommandService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/AuthCommandService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 
 import kr.co.abacus.abms.application.auth.dto.ChangePasswordCommand;
 import kr.co.abacus.abms.application.auth.dto.LoginCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetConfirmCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetRequestCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationConfirmCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationRequestCommand;
 import kr.co.abacus.abms.application.auth.inbound.AuthManager;
@@ -19,6 +21,8 @@ import kr.co.abacus.abms.application.auth.outbound.AccountPermissionGroupReposit
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.auth.outbound.CredentialAuthenticator;
 import kr.co.abacus.abms.application.auth.outbound.DefaultPermissionGroupRepository;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetLinkSender;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetTokenRepository;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationLinkSender;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationTokenRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
@@ -30,7 +34,9 @@ import kr.co.abacus.abms.domain.account.AccountAlreadyExistsException;
 import kr.co.abacus.abms.domain.account.AccountNotFoundException;
 import kr.co.abacus.abms.domain.account.InvalidCurrentPasswordException;
 import kr.co.abacus.abms.domain.account.SamePasswordException;
+import kr.co.abacus.abms.domain.auth.InvalidPasswordResetTokenException;
 import kr.co.abacus.abms.domain.auth.InvalidRegistrationTokenException;
+import kr.co.abacus.abms.domain.auth.PasswordResetToken;
 import kr.co.abacus.abms.domain.auth.RegistrationToken;
 import kr.co.abacus.abms.domain.employee.Employee;
 import kr.co.abacus.abms.domain.employee.EmployeeNotFoundException;
@@ -47,7 +53,9 @@ public class AuthCommandService implements AuthManager {
     private final AccountRepository accountRepository;
     private final EmployeeRepository employeeRepository;
     private final RegistrationTokenRepository registrationTokenRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final RegistrationLinkSender registrationLinkSender;
+    private final PasswordResetLinkSender passwordResetLinkSender;
     private final PasswordEncoder passwordEncoder;
     private final DefaultPermissionGroupRepository defaultPermissionGroupRepository;
     private final AccountPermissionGroupRepository accountPermissionGroupRepository;
@@ -134,9 +142,57 @@ public class AuthCommandService implements AuthManager {
         businessEventLogger.authEvent("change_password", email.address(), "success", null);
     }
 
+    @Override
+    public void requestPasswordReset(PasswordResetRequestCommand command) {
+        Email email = new Email(command.email());
+        accountRepository.findByUsername(email)
+                .filter(account -> Boolean.TRUE.equals(account.getIsValid()))
+                .filter(account -> !account.isDeleted())
+                .ifPresent(account -> issuePasswordResetToken(email, account));
+    }
+
+    @Override
+    public void confirmPasswordReset(PasswordResetConfirmCommand command) {
+        PasswordResetToken passwordResetToken = passwordResetTokenRepository.findByToken(command.token())
+                .orElseThrow(() -> new InvalidPasswordResetTokenException("유효하지 않은 비밀번호 재설정 토큰입니다."));
+        passwordResetToken.consume(LocalDateTime.now());
+
+        Account account = accountRepository.findByIdAndDeletedFalse(passwordResetToken.getAccountId())
+                .orElseThrow(() -> new AccountNotFoundException("계정을 찾을 수 없습니다."));
+
+        if (passwordEncoder.matches(command.password(), account.getPassword())) {
+            throw new SamePasswordException("새 비밀번호는 현재 비밀번호와 달라야 합니다.");
+        }
+
+        account.changePassword(Objects.requireNonNull(passwordEncoder.encode(command.password())));
+        passwordResetTokenRepository.delete(passwordResetToken);
+        businessEventLogger.authEvent("password_reset_confirm", passwordResetToken.getEmail().address(), "success", null);
+    }
+
     private void validateAlreadyRegistered(Email email) {
         if (accountRepository.findByUsername(email).isPresent()) {
             throw new AccountAlreadyExistsException("이미 가입된 계정입니다: " + email.address());
+        }
+    }
+
+    private void issuePasswordResetToken(Email email, Account account) {
+        String token = UUID.randomUUID().toString();
+        LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(30);
+
+        passwordResetTokenRepository.deleteAllByEmail(email);
+        passwordResetTokenRepository.save(PasswordResetToken.create(
+                account.getIdOrThrow(),
+                email.address(),
+                token,
+                expiresAt
+        ));
+
+        try {
+            passwordResetLinkSender.sendPasswordResetLink(email, token, expiresAt);
+            businessEventLogger.authEvent("password_reset_request", email.address(), "success", null);
+        } catch (RuntimeException exception) {
+            businessEventLogger.authEvent("password_reset_request", email.address(), "failure", exception.getClass().getSimpleName());
+            throw new PasswordResetMailSendException("비밀번호 재설정 메일 발송에 실패했습니다. 잠시 후 다시 시도해주세요.", exception);
         }
     }
 

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/PasswordResetMailSendException.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/PasswordResetMailSendException.java
@@ -1,0 +1,9 @@
+package kr.co.abacus.abms.application.auth;
+
+public class PasswordResetMailSendException extends RuntimeException {
+
+    public PasswordResetMailSendException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/PasswordResetConfirmCommand.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/PasswordResetConfirmCommand.java
@@ -1,0 +1,8 @@
+package kr.co.abacus.abms.application.auth.dto;
+
+public record PasswordResetConfirmCommand(
+        String token,
+        String password
+) {
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/PasswordResetRequestCommand.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/dto/PasswordResetRequestCommand.java
@@ -1,0 +1,7 @@
+package kr.co.abacus.abms.application.auth.dto;
+
+public record PasswordResetRequestCommand(
+        String email
+) {
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/inbound/AuthManager.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/inbound/AuthManager.java
@@ -1,6 +1,8 @@
 package kr.co.abacus.abms.application.auth.inbound;
 
 import kr.co.abacus.abms.application.auth.dto.LoginCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetConfirmCommand;
+import kr.co.abacus.abms.application.auth.dto.PasswordResetRequestCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationConfirmCommand;
 import kr.co.abacus.abms.application.auth.dto.RegistrationRequestCommand;
 import kr.co.abacus.abms.application.auth.dto.ChangePasswordCommand;
@@ -14,5 +16,9 @@ public interface AuthManager {
     void login(LoginCommand command);
 
     void changePassword(ChangePasswordCommand command);
+
+    void requestPasswordReset(PasswordResetRequestCommand command);
+
+    void confirmPasswordReset(PasswordResetConfirmCommand command);
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/PasswordResetLinkSender.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/PasswordResetLinkSender.java
@@ -1,0 +1,11 @@
+package kr.co.abacus.abms.application.auth.outbound;
+
+import java.time.LocalDateTime;
+
+import kr.co.abacus.abms.domain.shared.Email;
+
+public interface PasswordResetLinkSender {
+
+    void sendPasswordResetLink(Email email, String token, LocalDateTime expiresAt);
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/PasswordResetTokenRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/auth/outbound/PasswordResetTokenRepository.java
@@ -1,0 +1,20 @@
+package kr.co.abacus.abms.application.auth.outbound;
+
+import java.util.Optional;
+
+import kr.co.abacus.abms.domain.auth.PasswordResetToken;
+import kr.co.abacus.abms.domain.shared.Email;
+
+public interface PasswordResetTokenRepository {
+
+    PasswordResetToken save(PasswordResetToken passwordResetToken);
+
+    Optional<PasswordResetToken> findByToken(String token);
+
+    Optional<PasswordResetToken> findFirstByEmailOrderByCreatedAtDesc(Email email);
+
+    void delete(PasswordResetToken passwordResetToken);
+
+    void deleteAllByEmail(Email email);
+
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/dashboard/DashboardQueryService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/dashboard/DashboardQueryService.java
@@ -230,18 +230,8 @@ public class DashboardQueryService implements DashboardFinder {
     private List<MonthlyRevenueSummary> getLatestProjectSnapshotsByMonth(int year) {
         LocalDate startDate = LocalDate.of(year, Month.JANUARY, 1);
         LocalDate endDate = LocalDate.of(year, Month.DECEMBER, 31);
-        List<MonthlyRevenueSummary> summaries = monthlyRevenueSummaryRepository
+        return monthlyRevenueSummaryRepository
                 .findAllBySummaryDateBetweenAndDeletedFalseOrderBySummaryDateAscIdAsc(startDate, endDate);
-
-        Map<ProjectMonthKey, MonthlyRevenueSummary> latestProjectSnapshots = new LinkedHashMap<>();
-        for (MonthlyRevenueSummary summary : summaries) {
-            latestProjectSnapshots.put(
-                    new ProjectMonthKey(YearMonth.from(summary.getSummaryDate()), summary.getProjectId()),
-                    summary
-            );
-        }
-
-        return latestProjectSnapshots.values().stream().toList();
     }
 
     private boolean hasVisibleAmounts(DepartmentFinancialAccumulator accumulator) {
@@ -304,9 +294,6 @@ public class DashboardQueryService implements DashboardFinder {
         private long profit() {
             return profit.amount().longValue();
         }
-    }
-
-    private record ProjectMonthKey(YearMonth month, Long projectId) {
     }
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/summary/outbound/MonthlyRevenueSummaryRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/summary/outbound/MonthlyRevenueSummaryRepository.java
@@ -21,5 +21,7 @@ public interface MonthlyRevenueSummaryRepository {
         LocalDate end
     );
 
+    void deleteBySummaryDateBetween(LocalDate start, LocalDate end);
+
     <S extends MonthlyRevenueSummary> List<S> saveAll(Iterable<S> summaries);
 }

--- a/abms-batch-boot/src/test/java/kr/co/abacus/abms/adapter/batch/BatchJobStructureTest.java
+++ b/abms-batch-boot/src/test/java/kr/co/abacus/abms/adapter/batch/BatchJobStructureTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import kr.co.abacus.abms.application.auth.outbound.PasswordResetLinkSender;
 import kr.co.abacus.abms.AbmsBatchApplication;
 import kr.co.abacus.abms.application.auth.outbound.RegistrationLinkSender;
 import kr.co.abacus.abms.application.department.outbound.DepartmentRepository;
@@ -72,6 +73,9 @@ class BatchJobStructureTest {
 
     @MockitoBean
     private RegistrationLinkSender registrationLinkSender;
+
+    @MockitoBean
+    private PasswordResetLinkSender passwordResetLinkSender;
 
     @Autowired
     private JobLauncher jobLauncher;
@@ -230,8 +234,8 @@ class BatchJobStructureTest {
     }
 
     @Test
-    @DisplayName("revenueMonthlySummaryJob는 같은 월 재실행 시 요약을 추가 적재한다")
-    void revenueMonthlySummaryJob_appendsSummaryOnRerun() throws Exception {
+    @DisplayName("revenueMonthlySummaryJob는 같은 월 재실행 시 기존 요약을 삭제하고 다시 적재하여 멱등성을 보장한다")
+    void revenueMonthlySummaryJob_isIdempotentOnRerun() throws Exception {
         LocalDate targetDate = LocalDate.of(2026, 2, 15);
         Department leadDepartment = createDepartment("집계팀B");
         Employee employee = createEmployee(leadDepartment, "집계직원B", "batch-summary-b@abms.co.kr");
@@ -285,7 +289,7 @@ class BatchJobStructureTest {
                 .filter(summary -> summary.getSummaryDate().isEqual(targetDate))
                 .toList();
 
-        assertThat(summaries).hasSize(2);
+        assertThat(summaries).hasSize(1);
     }
 
     private JobParameters jobParameters(LocalDate targetDate, long runId) {

--- a/abms-domain/ddl.sql
+++ b/abms-domain/ddl.sql
@@ -284,6 +284,31 @@ CREATE TABLE IF NOT EXISTS `tb_registration_token` (
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;
 
+CREATE TABLE IF NOT EXISTS `tb_password_reset_token` (
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT,
+    `account_id` BIGINT      NOT NULL,
+    `email`      VARCHAR(100) NOT NULL,
+    `token`      VARCHAR(100) NOT NULL,
+    `expires_at` DATETIME(6)  NOT NULL,
+    `used`       TINYINT(1)   NOT NULL,
+    `used_at`    DATETIME(6)  NULL,
+    `created_at` DATETIME(6)  NOT NULL,
+    `updated_at` DATETIME(6)  NOT NULL,
+    `created_by` BIGINT       NULL,
+    `updated_by` BIGINT       NULL,
+    `deleted`    TINYINT(1)   NOT NULL,
+    `deleted_at` DATETIME(6)  NULL,
+    `deleted_by` BIGINT       NULL,
+
+    PRIMARY KEY (`id`),
+    CONSTRAINT `UK_PASSWORD_RESET_TOKEN` UNIQUE (`token`),
+    INDEX `IDX_PASSWORD_RESET_TOKEN_ACCOUNT_ID` (`account_id`),
+    INDEX `IDX_PASSWORD_RESET_TOKEN_EMAIL` (`email`),
+    CONSTRAINT `FK_PASSWORD_RESET_TOKEN_ACCOUNT_ID` FOREIGN KEY (`account_id`) REFERENCES `tb_account` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
 CREATE TABLE IF NOT EXISTS `tb_chat_message` (
     `id`              BIGINT       NOT NULL AUTO_INCREMENT,
     `role`            INT          NOT NULL,

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/auth/InvalidPasswordResetTokenException.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/auth/InvalidPasswordResetTokenException.java
@@ -1,0 +1,9 @@
+package kr.co.abacus.abms.domain.auth;
+
+public class InvalidPasswordResetTokenException extends RuntimeException {
+
+    public InvalidPasswordResetTokenException(String message) {
+        super(message);
+    }
+
+}

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/auth/PasswordResetToken.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/auth/PasswordResetToken.java
@@ -1,0 +1,74 @@
+package kr.co.abacus.abms.domain.auth;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import org.jspecify.annotations.Nullable;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import kr.co.abacus.abms.domain.AbstractEntity;
+import kr.co.abacus.abms.domain.shared.Email;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_password_reset_token", uniqueConstraints = {
+        @UniqueConstraint(name = "UK_PASSWORD_RESET_TOKEN", columnNames = "token")
+})
+public class PasswordResetToken extends AbstractEntity {
+
+    @Column(name = "account_id", nullable = false)
+    private Long accountId;
+
+    @Embedded
+    @AttributeOverride(name = "address", column = @Column(name = "email", nullable = false, length = 100))
+    private Email email;
+
+    @Column(name = "token", nullable = false, length = 100)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used", nullable = false)
+    private Boolean used;
+
+    @Nullable
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    public static PasswordResetToken create(Long accountId, String email, String token, LocalDateTime expiresAt) {
+        PasswordResetToken passwordResetToken = new PasswordResetToken();
+
+        passwordResetToken.accountId = Objects.requireNonNull(accountId);
+        passwordResetToken.email = new Email(Objects.requireNonNull(email));
+        passwordResetToken.token = Objects.requireNonNull(token);
+        passwordResetToken.expiresAt = Objects.requireNonNull(expiresAt);
+        passwordResetToken.used = false;
+
+        return passwordResetToken;
+    }
+
+    public void consume(LocalDateTime now) {
+        if (Boolean.TRUE.equals(used)) {
+            throw new InvalidPasswordResetTokenException("이미 사용된 비밀번호 재설정 토큰입니다.");
+        }
+        if (expiresAt.isBefore(now)) {
+            throw new InvalidPasswordResetTokenException("만료된 비밀번호 재설정 토큰입니다.");
+        }
+
+        this.used = true;
+        this.usedAt = now;
+    }
+
+}

--- a/docs/도메인모델.md
+++ b/docs/도메인모델.md
@@ -314,14 +314,27 @@
 - `create()`
 - `consume()`
 
-### 4.3 Permission
+### 4.3 PasswordResetToken
+
+비밀번호 재설정 확인용 토큰 엔티티입니다.
+
+- `accountId`: `Long`
+- `email`: `Email`
+- `token`: `String`
+- `expiresAt`: `LocalDateTime`
+- `used`: `Boolean`
+- `usedAt`: `LocalDateTime?`
+- `create()`
+- `consume()`
+
+### 4.4 Permission
 
 - `code`: `String`
 - `name`: `String`
 - `description`: `String`
 - `create()`
 
-### 4.4 PermissionGroup
+### 4.5 PermissionGroup
 
 - `name`: `String`
 - `description`: `String`
@@ -330,18 +343,18 @@
 - `updateInfo()`
 - `isSystemGroup()`
 
-### 4.5 PermissionGroupType
+### 4.6 PermissionGroupType
 
 - `SYSTEM`, `CUSTOM`
 
-### 4.6 GroupPermissionGrant
+### 4.7 GroupPermissionGrant
 
 - `permissionGroupId`: `Long`
 - `permissionId`: `Long`
 - `scope`: `PermissionScope`
 - `create()`
 
-### 4.7 PermissionScope
+### 4.8 PermissionScope
 
 - `ALL`
 - `OWN_DEPARTMENT`
@@ -349,7 +362,7 @@
 - `CURRENT_PARTICIPATION`
 - `SELF`
 
-### 4.8 AccountGroupAssignment
+### 4.9 AccountGroupAssignment
 
 - `accountId`: `Long`
 - `permissionGroupId`: `Long`

--- a/docs/인증가이드.md
+++ b/docs/인증가이드.md
@@ -124,7 +124,30 @@
 - 비밀번호 정책(길이/복잡도/재사용 제한) 검증기를 분리해 주입
 - 변경 이벤트 감사 로그(누가, 언제, IP) 저장
 
-### 3.6 가입 요청/가입 확정(이메일 토큰 방식)
+### 3.6 비밀번호 찾기/재설정
+
+### 재설정 요청
+`POST /api/auth/password-reset-requests`
+1. 회사 이메일 형식 검증
+2. 활성 계정이 있으면 30분 만료 재설정 토큰 생성
+3. 기존 재설정 토큰 삭제 후 새 토큰 저장
+4. 재설정 링크 메일 발송
+5. 계정 존재 여부와 무관하게 외부 응답은 성공으로 통일
+
+### 재설정 확정
+`POST /api/auth/password-reset-confirmations`
+1. 토큰 조회 및 유효성 검증(만료/사용 처리)
+2. 계정 조회
+3. 신규 비밀번호가 기존과 같으면 예외
+4. 인코딩 후 계정 비밀번호 변경
+5. 사용된 토큰 삭제
+
+핵심 포인트:
+- 계정 존재 여부를 응답으로 노출하지 않아 이메일 열거를 방지합니다.
+- 가입 토큰과 별도 엔티티를 사용해 목적, 메일 문구, 만료/사용 이력을 분리합니다.
+- 비밀번호 정책은 회원가입/비밀번호 변경과 동일하게 유지합니다.
+
+### 3.7 가입 요청/가입 확정(이메일 토큰 방식)
 
 ### 가입 요청
 `POST /api/auth/registration-requests`
@@ -147,7 +170,7 @@
 - 토큰 단건 사용(consumed) 패턴으로 재사용 방지
 - 가입 직후 기본 권한 그룹 부여로 초기 접근 정책 일관성 확보
 
-### 3.7 CSRF 초기화 엔드포인트
+### 3.8 CSRF 초기화 엔드포인트
 
 `GET /api/csrf`:
 - 빈 `200 OK` 응답
@@ -167,6 +190,8 @@
 - `useChangePasswordMutation`
 - `useRequestRegistrationMutation`
 - `useConfirmRegistrationMutation`
+- `useRequestPasswordResetMutation`
+- `useConfirmPasswordResetMutation`
 
 특징:
 - 로그인 성공 시 `authKeys.me()` invalidate
@@ -211,6 +236,10 @@
   - response: `{ name, email, employeeId?, departmentId?, permissions[] }`
 - `PATCH /api/auth/password`
   - request: `{ currentPassword, newPassword }`
+- `POST /api/auth/password-reset-requests`
+  - request: `{ email }`
+- `POST /api/auth/password-reset-confirmations`
+  - request: `{ token, password }`
 - `POST /api/auth/registration-requests`
   - request: `{ email }`
 - `POST /api/auth/registration-confirmations`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -100,6 +100,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -583,27 +584,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1692,9 +1672,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1707,9 +1684,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1724,9 +1698,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1739,9 +1710,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1756,9 +1724,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1771,9 +1736,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1788,9 +1750,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1803,9 +1762,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1820,9 +1776,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1835,9 +1788,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1852,9 +1802,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1868,9 +1815,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1883,9 +1827,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3057,6 +2998,7 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3415,6 +3357,7 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -4029,6 +3972,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4193,6 +4137,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4299,6 +4244,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4992,6 +4938,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5304,7 +5251,8 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-reactive-utils": {
       "version": "8.6.0",
@@ -5511,6 +5459,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5583,6 +5532,7 @@
       "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -6192,6 +6142,7 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7463,7 +7414,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -8554,7 +8506,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -8639,6 +8592,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8792,6 +8746,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9194,6 +9149,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9403,6 +9359,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9416,6 +9373,7 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -9536,6 +9494,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/compiler-sfc": "3.5.32",
@@ -9943,6 +9902,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -584,16 +583,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1483,24 +1472,6 @@
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2239,6 +2210,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -2431,16 +2460,6 @@
       },
       "peerDependencies": {
         "vue": "^2.7.0 || ^3.0.0"
-      }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/chai": {
@@ -2998,7 +3017,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -3357,7 +3375,6 @@
       "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.4",
@@ -3972,7 +3989,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4137,7 +4153,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -4244,7 +4259,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4938,7 +4952,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5251,8 +5264,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-reactive-utils": {
       "version": "8.6.0",
@@ -5459,7 +5471,6 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5532,7 +5543,6 @@
       "integrity": "sha512-f1J/tcbnrpgC8suPN5AtdJ5MQjuXbSU9pGRSSYAuF3SHoiYCOdEX6O22pLaRyLHXvDcOe+O5ENgc1owQ587agA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -6142,7 +6152,6 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -7414,8 +7423,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -8506,8 +8514,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
@@ -8592,7 +8599,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8746,7 +8752,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9149,7 +9154,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9359,7 +9363,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9373,7 +9376,6 @@
       "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.4",
         "@vitest/mocker": "4.1.4",
@@ -9494,7 +9496,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/compiler-sfc": "3.5.32",
@@ -9902,7 +9903,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/core/router/index.ts
+++ b/frontend/src/core/router/index.ts
@@ -52,6 +52,24 @@ const routes = [
         },
       },
       {
+        path: 'password-reset',
+        name: 'auth-password-reset',
+        component: () => import('@/features/auth/views/AuthPasswordResetRequestView.vue'),
+        meta: {
+          title: '비밀번호 찾기',
+          layout: AuthLayout,
+        },
+      },
+      {
+        path: 'password-reset-confirm',
+        name: 'auth-password-reset-confirm',
+        component: () => import('@/features/auth/views/AuthPasswordResetConfirmView.vue'),
+        meta: {
+          title: '비밀번호 재설정',
+          layout: AuthLayout,
+        },
+      },
+      {
         path: 'session-expired',
         name: 'auth-session-expired',
         component: () => import('@/features/auth/views/AuthSessionExpiredView.vue'),

--- a/frontend/src/features/auth/queries/useAuthQueries.ts
+++ b/frontend/src/features/auth/queries/useAuthQueries.ts
@@ -61,3 +61,20 @@ export function useConfirmRegistrationMutation() {
       repository.confirmRegistration(payload),
   });
 }
+
+export function useRequestPasswordResetMutation() {
+  const repository = appContainer.resolve(AuthRepository);
+
+  return useMutation({
+    mutationFn: (payload: { email: string }) => repository.requestPasswordReset(payload),
+  });
+}
+
+export function useConfirmPasswordResetMutation() {
+  const repository = appContainer.resolve(AuthRepository);
+
+  return useMutation({
+    mutationFn: (payload: { token: string; password: string }) =>
+      repository.confirmPasswordReset(payload),
+  });
+}

--- a/frontend/src/features/auth/repository/AuthRepository.ts
+++ b/frontend/src/features/auth/repository/AuthRepository.ts
@@ -20,6 +20,15 @@ interface ChangePasswordPayload {
   newPassword: string;
 }
 
+interface PasswordResetRequestPayload {
+  email: string;
+}
+
+interface PasswordResetConfirmPayload {
+  token: string;
+  password: string;
+}
+
 export interface AuthMeResponse {
   name: string;
   email: string;
@@ -67,6 +76,20 @@ export default class AuthRepository {
   async changePassword(payload: ChangePasswordPayload): Promise<void> {
     await this.httpRepository.patch<void>({
       path: '/api/auth/password',
+      data: payload,
+    });
+  }
+
+  async requestPasswordReset(payload: PasswordResetRequestPayload): Promise<void> {
+    await this.httpRepository.post<void>({
+      path: '/api/auth/password-reset-requests',
+      data: payload,
+    });
+  }
+
+  async confirmPasswordReset(payload: PasswordResetConfirmPayload): Promise<void> {
+    await this.httpRepository.post<void>({
+      path: '/api/auth/password-reset-confirmations',
       data: payload,
     });
   }

--- a/frontend/src/features/auth/repository/__tests__/AuthRepository.spec.ts
+++ b/frontend/src/features/auth/repository/__tests__/AuthRepository.spec.ts
@@ -86,6 +86,34 @@ describe('AuthRepository', () => {
     });
   });
 
+  it('비밀번호 재설정 요청 API를 호출한다', async () => {
+    await repository.requestPasswordReset({
+      email: 'user@iabacus.co.kr',
+    });
+
+    expect(httpPost).toHaveBeenCalledWith({
+      path: '/api/auth/password-reset-requests',
+      data: {
+        email: 'user@iabacus.co.kr',
+      },
+    });
+  });
+
+  it('비밀번호 재설정 확정 API를 호출한다', async () => {
+    await repository.confirmPasswordReset({
+      token: 'reset-token',
+      password: 'Password123!',
+    });
+
+    expect(httpPost).toHaveBeenCalledWith({
+      path: '/api/auth/password-reset-confirmations',
+      data: {
+        token: 'reset-token',
+        password: 'Password123!',
+      },
+    });
+  });
+
   it('현재 사용자 정보를 조회한다', async () => {
     httpGet.mockResolvedValueOnce({
       name: '인증사용자',

--- a/frontend/src/features/auth/views/AuthLoginView.spec.ts
+++ b/frontend/src/features/auth/views/AuthLoginView.spec.ts
@@ -47,6 +47,11 @@ const routes: RouteRecordRaw[] = [
     name: 'auth-register',
     component: { template: '<div>register</div>' },
   },
+  {
+    path: '/auths/password-reset',
+    name: 'auth-password-reset',
+    component: { template: '<div>password reset</div>' },
+  },
 ];
 
 async function mountLoginView(path = '/auths/login') {
@@ -97,6 +102,15 @@ describe('AuthLoginView', () => {
 
     expect(wrapper.text()).toContain('비밀번호를 입력해 주세요.');
     expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('비밀번호 찾기 링크를 제공한다', async () => {
+    const { wrapper } = await mountLoginView();
+
+    const link = wrapper.find('a[href="/auths/password-reset"]');
+
+    expect(link.exists()).toBe(true);
+    expect(link.text()).toContain('비밀번호를 잊으셨나요?');
   });
 
   it('이메일을 trim/lowercase 처리해서 로그인 요청을 보낸다', async () => {

--- a/frontend/src/features/auth/views/AuthLoginView.vue
+++ b/frontend/src/features/auth/views/AuthLoginView.vue
@@ -20,7 +20,15 @@
         </div>
 
         <div class="space-y-2">
-          <Label for="password">비밀번호</Label>
+          <div class="flex items-center justify-between gap-3">
+            <Label for="password">비밀번호</Label>
+            <RouterLink
+              class="text-xs font-medium text-primary underline-offset-4 hover:underline"
+              to="/auths/password-reset"
+            >
+              비밀번호를 잊으셨나요?
+            </RouterLink>
+          </div>
           <Input
             id="password"
             v-model="password"

--- a/frontend/src/features/auth/views/AuthPasswordResetConfirmView.spec.ts
+++ b/frontend/src/features/auth/views/AuthPasswordResetConfirmView.spec.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { type RouteRecordRaw } from 'vue-router';
+import HttpError from '@/core/http/HttpError';
+import AuthPasswordResetConfirmView from '@/features/auth/views/AuthPasswordResetConfirmView.vue';
+import { renderWithProviders } from '@/test-utils';
+import { toast } from 'vue-sonner';
+
+const mutateAsyncMock = vi.fn();
+
+vi.mock('@/features/auth/queries/useAuthQueries', () => ({
+  useConfirmPasswordResetMutation: () => ({
+    mutateAsync: mutateAsyncMock,
+  }),
+}));
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const routes: RouteRecordRaw[] = [
+  {
+    path: '/auths/password-reset-confirm',
+    name: 'auth-password-reset-confirm',
+    component: AuthPasswordResetConfirmView,
+  },
+  { path: '/auths/password-reset', name: 'auth-password-reset', component: { template: '<div>reset</div>' } },
+  { path: '/auths/login', name: 'auth-login', component: { template: '<div>login</div>' } },
+];
+
+async function mountView(path = '/auths/password-reset-confirm?token=reset-token') {
+  return renderWithProviders(AuthPasswordResetConfirmView, {
+    routes,
+    route: path,
+  });
+}
+
+describe('AuthPasswordResetConfirmView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsyncMock.mockResolvedValue(undefined);
+  });
+
+  it('토큰이 없으면 제출할 수 없다는 안내를 보여준다', async () => {
+    const { wrapper } = await mountView('/auths/password-reset-confirm');
+
+    expect(wrapper.text()).toContain('비밀번호 재설정 토큰이 없습니다.');
+    expect(wrapper.find('button[type="submit"]').attributes('disabled')).toBeDefined();
+  });
+
+  it('비밀번호 확인이 다르면 검증 메시지를 보여준다', async () => {
+    const { wrapper } = await mountView();
+
+    await wrapper.find('#password').setValue('ResetPassword123!');
+    await wrapper.find('#passwordConfirm').setValue('OtherPassword123!');
+    await wrapper.find('form').trigger('submit.prevent');
+
+    expect(wrapper.text()).toContain('비밀번호가 일치하지 않습니다.');
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('토큰과 새 비밀번호로 재설정을 확정하고 로그인 화면으로 이동한다', async () => {
+    const { wrapper, router } = await mountView();
+
+    await wrapper.find('#password').setValue('ResetPassword123!');
+    await wrapper.find('#passwordConfirm').setValue('ResetPassword123!');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({
+      token: 'reset-token',
+      password: 'ResetPassword123!',
+    });
+    expect(toast.success).toHaveBeenCalledWith('비밀번호를 재설정했습니다. 새 비밀번호로 로그인해 주세요.');
+    expect(router.currentRoute.value.path).toBe('/auths/login');
+  });
+
+  it('재설정 실패 시 서버 메시지를 보여준다', async () => {
+    mutateAsyncMock.mockRejectedValueOnce(new HttpError({ message: '만료된 토큰입니다.' }));
+    const { wrapper } = await mountView();
+
+    await wrapper.find('#password').setValue('ResetPassword123!');
+    await wrapper.find('#passwordConfirm').setValue('ResetPassword123!');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('만료된 토큰입니다.');
+    expect(toast.error).toHaveBeenCalledWith('비밀번호 재설정에 실패했습니다.', {
+      description: '만료된 토큰입니다.',
+    });
+  });
+});

--- a/frontend/src/features/auth/views/AuthPasswordResetConfirmView.vue
+++ b/frontend/src/features/auth/views/AuthPasswordResetConfirmView.vue
@@ -1,0 +1,139 @@
+<template>
+  <Card class="w-full">
+    <CardHeader class="space-y-1">
+      <CardTitle class="text-2xl">비밀번호 재설정</CardTitle>
+      <CardDescription>새 비밀번호를 설정해 계정 접근을 복구하세요.</CardDescription>
+    </CardHeader>
+
+    <CardContent class="space-y-4">
+      <Alert v-if="!token" variant="destructive">
+        <AlertTitle>유효하지 않은 접근</AlertTitle>
+        <AlertDescription>
+          비밀번호 재설정 토큰이 없습니다. 비밀번호 찾기 화면에서 다시 링크를 발급해 주세요.
+        </AlertDescription>
+      </Alert>
+
+      <form class="space-y-4" @submit.prevent="submitConfirmation">
+        <div class="space-y-2">
+          <Label for="password">새 비밀번호</Label>
+          <Input
+            id="password"
+            v-model="password"
+            type="password"
+            autocomplete="new-password"
+            :disabled="!token"
+            required
+          />
+          <p class="text-xs text-muted-foreground">
+            8~64자이며 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다.
+          </p>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="passwordConfirm">새 비밀번호 확인</Label>
+          <Input
+            id="passwordConfirm"
+            v-model="passwordConfirm"
+            type="password"
+            autocomplete="new-password"
+            :disabled="!token"
+            required
+          />
+        </div>
+
+        <Alert v-if="errorMessage" variant="destructive">
+          <AlertTitle>재설정 실패</AlertTitle>
+          <AlertDescription>{{ errorMessage }}</AlertDescription>
+        </Alert>
+
+        <Button type="submit" class="w-full" :disabled="isSubmitting || !token">
+          {{ isSubmitting ? '처리 중...' : '비밀번호 재설정' }}
+        </Button>
+      </form>
+
+      <div class="space-y-2">
+        <Button class="w-full" variant="outline" as-child>
+          <RouterLink to="/auths/password-reset">비밀번호 찾기로 이동</RouterLink>
+        </Button>
+        <Button class="w-full" variant="ghost" as-child>
+          <RouterLink to="/auths/login">로그인으로 이동</RouterLink>
+        </Button>
+      </div>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { toast } from 'vue-sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import HttpError from '@/core/http/HttpError';
+import { useConfirmPasswordResetMutation } from '@/features/auth/queries/useAuthQueries';
+
+const route = useRoute();
+const router = useRouter();
+const confirmPasswordResetMutation = useConfirmPasswordResetMutation();
+
+const password = ref('');
+const passwordConfirm = ref('');
+const errorMessage = ref<string | null>(null);
+const isSubmitting = ref(false);
+const STRONG_PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,64}$/;
+
+const token = computed(() => {
+  const value = route.query.token;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '';
+  }
+  return '';
+});
+
+function validateForm(): string | null {
+  if (!token.value) {
+    return '유효한 비밀번호 재설정 토큰이 필요합니다.';
+  }
+  if (password.value.length < 8) {
+    return '비밀번호는 8자 이상이어야 합니다.';
+  }
+  if (!STRONG_PASSWORD_PATTERN.test(password.value)) {
+    return '비밀번호는 영문, 숫자, 특수문자를 각각 1자 이상 포함해야 합니다.';
+  }
+  if (password.value !== passwordConfirm.value) {
+    return '비밀번호가 일치하지 않습니다.';
+  }
+  return null;
+}
+
+async function submitConfirmation() {
+  errorMessage.value = null;
+  const validationError = validateForm();
+  if (validationError) {
+    errorMessage.value = validationError;
+    return;
+  }
+
+  isSubmitting.value = true;
+  try {
+    await confirmPasswordResetMutation.mutateAsync({
+      token: token.value,
+      password: password.value,
+    });
+
+    toast.success('비밀번호를 재설정했습니다. 새 비밀번호로 로그인해 주세요.');
+    await router.push('/auths/login');
+  } catch (error) {
+    const message =
+      error instanceof HttpError ? error.message : '비밀번호 재설정 중 오류가 발생했습니다.';
+    errorMessage.value = message;
+    toast.error('비밀번호 재설정에 실패했습니다.', { description: message });
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>

--- a/frontend/src/features/auth/views/AuthPasswordResetRequestView.spec.ts
+++ b/frontend/src/features/auth/views/AuthPasswordResetRequestView.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushPromises } from '@vue/test-utils';
+import { type RouteRecordRaw } from 'vue-router';
+import HttpError from '@/core/http/HttpError';
+import AuthPasswordResetRequestView from '@/features/auth/views/AuthPasswordResetRequestView.vue';
+import { renderWithProviders } from '@/test-utils';
+import { toast } from 'vue-sonner';
+
+const mutateAsyncMock = vi.fn();
+
+vi.mock('@/features/auth/queries/useAuthQueries', () => ({
+  useRequestPasswordResetMutation: () => ({
+    mutateAsync: mutateAsyncMock,
+  }),
+}));
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const routes: RouteRecordRaw[] = [
+  { path: '/auths/password-reset', name: 'auth-password-reset', component: AuthPasswordResetRequestView },
+  { path: '/auths/login', name: 'auth-login', component: { template: '<div>login</div>' } },
+];
+
+async function mountView() {
+  return renderWithProviders(AuthPasswordResetRequestView, {
+    routes,
+    route: '/auths/password-reset',
+  });
+}
+
+describe('AuthPasswordResetRequestView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsyncMock.mockResolvedValue(undefined);
+  });
+
+  it('회사 이메일이 아니면 검증 메시지를 보여준다', async () => {
+    const { wrapper } = await mountView();
+
+    await wrapper.find('#email').setValue('user@example.com');
+    await wrapper.find('form').trigger('submit.prevent');
+
+    expect(wrapper.text()).toContain('회사 이메일(@iabacus.co.kr)만 사용할 수 있습니다.');
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('이메일을 trim/lowercase 처리해서 재설정 요청을 보낸다', async () => {
+    const { wrapper } = await mountView();
+
+    await wrapper.find('#email').setValue('  User@IABACUS.CO.KR  ');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    expect(mutateAsyncMock).toHaveBeenCalledWith({ email: 'user@iabacus.co.kr' });
+    expect(wrapper.text()).toContain('입력한 이메일이 가입된 계정이면');
+    expect(toast.success).toHaveBeenCalledWith('비밀번호 재설정 안내를 확인해 주세요.');
+  });
+
+  it('요청 실패 시 서버 메시지를 보여준다', async () => {
+    mutateAsyncMock.mockRejectedValueOnce(new HttpError({ message: '메일 발송 실패' }));
+    const { wrapper } = await mountView();
+
+    await wrapper.find('#email').setValue('user@iabacus.co.kr');
+    await wrapper.find('form').trigger('submit.prevent');
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('메일 발송 실패');
+    expect(toast.error).toHaveBeenCalledWith('비밀번호 재설정 요청에 실패했습니다.', {
+      description: '메일 발송 실패',
+    });
+  });
+});

--- a/frontend/src/features/auth/views/AuthPasswordResetRequestView.vue
+++ b/frontend/src/features/auth/views/AuthPasswordResetRequestView.vue
@@ -1,0 +1,113 @@
+<template>
+  <Card class="w-full">
+    <CardHeader class="space-y-1">
+      <CardTitle class="text-2xl">비밀번호 찾기</CardTitle>
+      <CardDescription>
+        회사 이메일로 비밀번호 재설정 링크를 받을 수 있습니다.
+      </CardDescription>
+    </CardHeader>
+
+    <CardContent class="space-y-4">
+      <div v-if="isSent" class="space-y-4">
+        <Alert>
+          <AlertTitle>메일 확인 안내</AlertTitle>
+          <AlertDescription>
+            입력한 이메일이 가입된 계정이면 비밀번호 재설정 링크를 발송했습니다.
+            메일의 링크는 30분 동안 사용할 수 있습니다.
+          </AlertDescription>
+        </Alert>
+
+        <Button class="w-full" variant="outline" @click="isSent = false">다시 요청하기</Button>
+        <Button class="w-full" as-child>
+          <RouterLink to="/auths/login">로그인으로 이동</RouterLink>
+        </Button>
+      </div>
+
+      <form v-else class="space-y-4" @submit.prevent="submitRequest">
+        <div class="space-y-2">
+          <Label for="email">회사 이메일</Label>
+          <Input
+            id="email"
+            v-model="email"
+            type="email"
+            placeholder="name@iabacus.co.kr"
+            autocomplete="email"
+            required
+          />
+          <p class="text-xs text-muted-foreground">@iabacus.co.kr 도메인만 요청할 수 있습니다.</p>
+        </div>
+
+        <Alert v-if="errorMessage" variant="destructive">
+          <AlertTitle>요청 실패</AlertTitle>
+          <AlertDescription>{{ errorMessage }}</AlertDescription>
+        </Alert>
+
+        <Button type="submit" class="w-full" :disabled="isSubmitting">
+          {{ isSubmitting ? '요청 중...' : '재설정 링크 요청' }}
+        </Button>
+
+        <div class="text-center text-sm text-muted-foreground">
+          비밀번호가 기억나셨나요?
+          <RouterLink class="font-medium text-primary underline-offset-4 hover:underline" to="/auths/login">
+            로그인
+          </RouterLink>
+        </div>
+      </form>
+    </CardContent>
+  </Card>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { toast } from 'vue-sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import HttpError from '@/core/http/HttpError';
+import { useRequestPasswordResetMutation } from '@/features/auth/queries/useAuthQueries';
+
+const COMPANY_EMAIL_PATTERN = /^[A-Za-z0-9._%+-]+@iabacus\.co\.kr$/;
+
+const requestPasswordResetMutation = useRequestPasswordResetMutation();
+
+const email = ref('');
+const errorMessage = ref<string | null>(null);
+const isSubmitting = ref(false);
+const isSent = ref(false);
+
+function validateEmail(value: string): string | null {
+  if (!value) {
+    return '이메일을 입력해 주세요.';
+  }
+  if (!COMPANY_EMAIL_PATTERN.test(value)) {
+    return '회사 이메일(@iabacus.co.kr)만 사용할 수 있습니다.';
+  }
+  return null;
+}
+
+async function submitRequest() {
+  errorMessage.value = null;
+  const normalizedEmail = email.value.trim().toLowerCase();
+  const validationError = validateEmail(normalizedEmail);
+  if (validationError) {
+    errorMessage.value = validationError;
+    return;
+  }
+
+  isSubmitting.value = true;
+  try {
+    await requestPasswordResetMutation.mutateAsync({ email: normalizedEmail });
+    isSent.value = true;
+    toast.success('비밀번호 재설정 안내를 확인해 주세요.');
+  } catch (error) {
+    const message =
+      error instanceof HttpError ? error.message : '비밀번호 재설정 요청 중 오류가 발생했습니다.';
+    errorMessage.value = message;
+    toast.error('비밀번호 재설정 요청에 실패했습니다.', { description: message });
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>


### PR DESCRIPTION
## 변경 요약
- 비로그인 사용자가 이메일 토큰으로 비밀번호를 재설정할 수 있는 API와 전용 토큰 모델을 추가했습니다.
- 재설정 요청/확정 프런트 화면과 로그인 화면 진입 링크를 추가했습니다.
- REST Docs, 인증 가이드, 도메인 문서와 관련 테스트를 갱신했습니다.

## 관련 이슈 (필수)
- Closes #95
- Refs #95

## 핵심 검증 (필수)
- [x] 로컬에서 핵심 시나리오를 검증했다.
- 검증 내용 요약:
  - `./gradlew test`
  - `npm run lint`
  - `npm run typecheck`
  - `npm run test:unit -- AuthRepository AuthLoginView AuthPasswordResetRequestView AuthPasswordResetConfirmView`

## 증빙 자료 (조건부 필수)
- [ ] UI 변경 없음 (해당 시 아래 생략 가능)
- [x] UI 변경 있음: Before/After 캡처 첨부
- [ ] 동작 흐름 확인 필요: 짧은 영상(GIF/MP4) 첨부
- 첨부 링크/설명:
  - 비밀번호 찾기/재설정 화면이 추가되었습니다. 캡처는 PR 코멘트에 첨부 예정입니다.

## 영향도 (필수)
- API 변경: [x] 있음 [ ] 없음
- DB 스키마/데이터 마이그레이션: [x] 있음 [ ] 없음
- ENV 변수 추가/변경: [x] 있음 [ ] 없음

## 리뷰/머지 체크
- [ ] 팀원 1명 승인 완료
- [ ] CI 체크 통과

## Hotfix 예외
- [ ] 이 PR은 `hotfix/*` 이다. (체크 시 셀프 머지 허용)
- [ ] 사후 리뷰 이슈를 생성했고 24시간 내 리뷰한다.
