### PR TITLE
전사 월 손익에 비가용 인원 비용 반영

### DIFF
--- a/abms-adapter-batch/src/main/java/kr/co/abacus/abms/adapter/batch/RevenueMonthlySummaryBatchConfig.java
+++ b/abms-adapter-batch/src/main/java/kr/co/abacus/abms/adapter/batch/RevenueMonthlySummaryBatchConfig.java
@@ -27,17 +27,22 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import kr.co.abacus.abms.application.department.outbound.DepartmentRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeMonthlyCostRepository;
+import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
 import kr.co.abacus.abms.application.project.outbound.ProjectRepository;
 import kr.co.abacus.abms.application.project.outbound.ProjectRevenuePlanRepository;
 import kr.co.abacus.abms.application.projectassignment.outbound.ProjectAssignmentRepository;
-import kr.co.abacus.abms.application.summary.outbound.RevenueMonthClosingRepository;
+import kr.co.abacus.abms.application.summary.outbound.CompanyMonthlyCostSummaryRepository;
 import kr.co.abacus.abms.application.summary.outbound.MonthlyRevenueSummaryRepository;
+import kr.co.abacus.abms.application.summary.outbound.RevenueMonthClosingRepository;
 import kr.co.abacus.abms.domain.department.Department;
+import kr.co.abacus.abms.domain.employee.Employee;
 import kr.co.abacus.abms.domain.employee.EmployeeMonthlyCost;
+import kr.co.abacus.abms.domain.employee.EmployeeType;
 import kr.co.abacus.abms.domain.project.Project;
 import kr.co.abacus.abms.domain.project.ProjectRevenuePlan;
 import kr.co.abacus.abms.domain.projectassignment.ProjectAssignment;
 import kr.co.abacus.abms.domain.shared.Money;
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummaryCreateRequest;
 import kr.co.abacus.abms.domain.summary.RevenueMonthClosingStatus;
@@ -56,11 +61,13 @@ public class RevenueMonthlySummaryBatchConfig {
     private final PlatformTransactionManager transactionManager;
 
     private final ProjectRepository projectRepository;
+    private final EmployeeRepository employeeRepository;
     private final DepartmentRepository departmentRepository;
     private final ProjectRevenuePlanRepository revenuePlanRepository;
     private final ProjectAssignmentRepository assignmentRepository;
     private final EmployeeMonthlyCostRepository employeeMonthlyCostRepository;
     private final MonthlyRevenueSummaryRepository summaryRepository;
+    private final CompanyMonthlyCostSummaryRepository companyMonthlyCostSummaryRepository;
     private final RevenueMonthClosingRepository revenueMonthClosingRepository;
     private final BatchObservabilityListener batchObservabilityListener;
 
@@ -104,6 +111,7 @@ public class RevenueMonthlySummaryBatchConfig {
             for (Project project : projects) {
                 reconcileProjectSummary(project, monthStart, monthEnd, costMonth);
             }
+            reconcileCompanyMonthlyCostSummary(monthStart, monthEnd, costMonth);
 
             return RepeatStatus.FINISHED;
         };
@@ -203,6 +211,72 @@ public class RevenueMonthlySummaryBatchConfig {
             totalCost = totalCost.add(empCost.getTotalCost().multiply(mm));
         }
         return totalCost;
+    }
+
+    private void reconcileCompanyMonthlyCostSummary(LocalDate monthStart, LocalDate monthEnd, String costMonth) {
+        List<EmployeeMonthlyCost> monthlyCosts = employeeMonthlyCostRepository.findAllByCostMonthAndDeletedFalse(costMonth);
+        List<ProjectAssignment> assignments = assignmentRepository.findActiveAssignments(monthStart, monthEnd);
+        Set<Long> employeeIds = new LinkedHashSet<>();
+        monthlyCosts.stream()
+                .map(EmployeeMonthlyCost::getEmployeeId)
+                .forEach(employeeIds::add);
+        assignments.stream()
+                .map(ProjectAssignment::getEmployeeId)
+                .forEach(employeeIds::add);
+
+        Map<Long, Employee> employeesById = employeeIds.isEmpty()
+                ? Map.of()
+                : employeeRepository.findAllByIdInAndDeletedFalse(employeeIds.stream().toList()).stream()
+                .collect(Collectors.toMap(Employee::getIdOrThrow, Function.identity()));
+        Set<Long> fullTimeEmployeeIds = employeesById.values().stream()
+                .filter(employee -> employee.getType() == EmployeeType.FULL_TIME)
+                .map(Employee::getIdOrThrow)
+                .collect(Collectors.toSet());
+        Map<Long, EmployeeMonthlyCost> monthlyCostsByEmployeeId = monthlyCosts.stream()
+                .collect(Collectors.toMap(EmployeeMonthlyCost::getEmployeeId, Function.identity(), (left, right) -> left));
+
+        Money totalFullTimeEmployeeCost = monthlyCosts.stream()
+                .filter(cost -> fullTimeEmployeeIds.contains(cost.getEmployeeId()))
+                .map(EmployeeMonthlyCost::getTotalCost)
+                .reduce(Money.zero(), Money::add);
+        Money allocatedFullTimeEmployeeCost = calculateAllocatedFullTimeEmployeeCost(
+                assignments,
+                monthStart,
+                fullTimeEmployeeIds,
+                monthlyCostsByEmployeeId
+        );
+        Money unallocatedFullTimeEmployeeCost = totalFullTimeEmployeeCost.subtract(allocatedFullTimeEmployeeCost);
+
+        CompanyMonthlyCostSummary summary = companyMonthlyCostSummaryRepository
+                .findByTargetMonthAndDeletedFalse(monthStart)
+                .orElseGet(() -> CompanyMonthlyCostSummary.create(
+                        monthStart,
+                        totalFullTimeEmployeeCost,
+                        allocatedFullTimeEmployeeCost,
+                        unallocatedFullTimeEmployeeCost
+                ));
+        summary.update(totalFullTimeEmployeeCost, allocatedFullTimeEmployeeCost, unallocatedFullTimeEmployeeCost);
+        companyMonthlyCostSummaryRepository.saveAll(List.of(summary));
+    }
+
+    private Money calculateAllocatedFullTimeEmployeeCost(
+            List<ProjectAssignment> assignments,
+            LocalDate targetMonth,
+            Set<Long> fullTimeEmployeeIds,
+            Map<Long, EmployeeMonthlyCost> monthlyCostsByEmployeeId
+    ) {
+        Money allocatedCost = Money.zero();
+        for (ProjectAssignment assignment : assignments) {
+            Long employeeId = assignment.getEmployeeId();
+            if (!fullTimeEmployeeIds.contains(employeeId)) {
+                continue;
+            }
+            EmployeeMonthlyCost empCost = java.util.Optional.ofNullable(monthlyCostsByEmployeeId.get(employeeId))
+                    .orElseThrow(() -> new IllegalArgumentException("직원 비용 누락 - 직원(id=" + employeeId + "), 월(targetMonth=" + targetMonth + "): "));
+            BigDecimal mm = assignment.calculateManMonth(targetMonth);
+            allocatedCost = allocatedCost.add(empCost.getTotalCost().multiply(mm));
+        }
+        return allocatedCost;
     }
 
     private boolean overlaps(LocalDate startDate, LocalDate endDate, LocalDate monthStart, LocalDate monthEnd) {

--- a/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/summary/CompanyMonthlyCostSummaryRepository.java
+++ b/abms-adapter-persistence/src/main/java/kr/co/abacus/abms/adapter/infrastructure/summary/CompanyMonthlyCostSummaryRepository.java
@@ -1,0 +1,10 @@
+package kr.co.abacus.abms.adapter.infrastructure.summary;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
+
+public interface CompanyMonthlyCostSummaryRepository
+        extends JpaRepository<CompanyMonthlyCostSummary, Long>,
+        kr.co.abacus.abms.application.summary.outbound.CompanyMonthlyCostSummaryRepository {
+}

--- a/abms-adapter-persistence/src/main/resources/db/migration/V4__company_monthly_cost_summary.sql
+++ b/abms-adapter-persistence/src/main/resources/db/migration/V4__company_monthly_cost_summary.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS `tb_company_monthly_cost_summary` (
+    `id`                                  BIGINT      NOT NULL AUTO_INCREMENT,
+    `target_month`                        DATE        NOT NULL,
+    `calculated_at`                       DATETIME(6) NOT NULL,
+    `total_full_time_employee_cost`       DECIMAL(19, 0) NOT NULL,
+    `allocated_full_time_employee_cost`   DECIMAL(19, 0) NOT NULL,
+    `unallocated_full_time_employee_cost` DECIMAL(19, 0) NOT NULL,
+
+    `created_at`                          DATETIME(6) NOT NULL,
+    `updated_at`                          DATETIME(6) NOT NULL,
+    `created_by`                          BIGINT      NULL,
+    `updated_by`                          BIGINT      NULL,
+    `deleted`                             TINYINT(1)  NOT NULL,
+    `deleted_at`                          DATETIME(6) NULL,
+    `deleted_by`                          BIGINT      NULL,
+
+    PRIMARY KEY (`id`),
+    CONSTRAINT `UK_COMPANY_MONTHLY_COST_SUMMARY_TARGET_MONTH` UNIQUE (`target_month`),
+    INDEX `IDX_COMPANY_MONTHLY_COST_SUMMARY_TARGET_MONTH` (`target_month`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/summary/CompanyMonthlyCostSummaryApi.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/summary/CompanyMonthlyCostSummaryApi.java
@@ -1,0 +1,36 @@
+package kr.co.abacus.abms.adapter.api.summary;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import kr.co.abacus.abms.adapter.api.summary.dto.CompanyMonthlyCostSummaryResponse;
+import kr.co.abacus.abms.application.summary.inbound.CompanyMonthlyCostSummaryFinder;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/companyMonthlyCostSummary")
+public class CompanyMonthlyCostSummaryApi {
+
+    private final CompanyMonthlyCostSummaryFinder summaryFinder;
+
+    @GetMapping
+    public CompanyMonthlyCostSummaryResponse getCompanyMonthlyCostSummary(
+            @RequestParam("yearMonth") String yearMonth
+    ) {
+        return CompanyMonthlyCostSummaryResponse.of(summaryFinder.findByTargetMonth(yearMonth));
+    }
+
+    @GetMapping("/sixMonthTrend")
+    public List<CompanyMonthlyCostSummaryResponse> getSixMonthsCompanyCostTrend(
+            @RequestParam("yearMonth") String yearMonth
+    ) {
+        return summaryFinder.findRecentSixMonths(yearMonth).stream()
+                .map(CompanyMonthlyCostSummaryResponse::of)
+                .toList();
+    }
+}

--- a/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/summary/dto/CompanyMonthlyCostSummaryResponse.java
+++ b/abms-adapter-web/src/main/java/kr/co/abacus/abms/adapter/api/summary/dto/CompanyMonthlyCostSummaryResponse.java
@@ -1,0 +1,26 @@
+package kr.co.abacus.abms.adapter.api.summary.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummaryTotal;
+
+public record CompanyMonthlyCostSummaryResponse(
+        LocalDate targetMonth,
+        BigDecimal revenue,
+        BigDecimal projectAllocatedCost,
+        BigDecimal unallocatedEmployeeCost,
+        BigDecimal cost,
+        BigDecimal profit
+) {
+    public static CompanyMonthlyCostSummaryResponse of(CompanyMonthlyCostSummaryTotal summary) {
+        return new CompanyMonthlyCostSummaryResponse(
+                summary.targetMonth(),
+                summary.revenueAmount().amount(),
+                summary.projectAllocatedCostAmount().amount(),
+                summary.unallocatedEmployeeCostAmount().amount(),
+                summary.costAmount().amount(),
+                summary.profitAmount().amount()
+        );
+    }
+}

--- a/abms-api-boot/src/docs/asciidoc/index.adoc
+++ b/abms-api-boot/src/docs/asciidoc/index.adoc
@@ -167,6 +167,36 @@ include::{snippets}/monthly-revenue-summary/six-month-trend/http-request.adoc[]
 .HTTP response
 include::{snippets}/monthly-revenue-summary/six-month-trend/http-response.adoc[]
 
+== Company Monthly Cost Summary API
+
+=== Get Company Monthly Cost Summary
+
+.Query parameters
+include::{snippets}/company-monthly-cost-summary/get/query-parameters.adoc[]
+
+.Response body
+include::{snippets}/company-monthly-cost-summary/get/response-body.adoc[]
+
+.HTTP request
+include::{snippets}/company-monthly-cost-summary/get/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/company-monthly-cost-summary/get/http-response.adoc[]
+
+=== Get Company Monthly Cost Six Month Trend
+
+.Query parameters
+include::{snippets}/company-monthly-cost-summary/six-month-trend/query-parameters.adoc[]
+
+.Response body
+include::{snippets}/company-monthly-cost-summary/six-month-trend/response-body.adoc[]
+
+.HTTP request
+include::{snippets}/company-monthly-cost-summary/six-month-trend/http-request.adoc[]
+
+.HTTP response
+include::{snippets}/company-monthly-cost-summary/six-month-trend/http-response.adoc[]
+
 == Common Error Response
 
 ABMS API는 도메인 오류와 검증 오류에 대해 `ProblemDetail` 형식의 공통 오류 응답을 사용합니다.

--- a/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/summary/MonthlyRevenueSummaryApiTest.java
+++ b/abms-api-boot/src/test/java/kr/co/abacus/abms/adapter/api/summary/MonthlyRevenueSummaryApiTest.java
@@ -23,6 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MvcResult;
 
 import kr.co.abacus.abms.adapter.infrastructure.summary.MonthlyRevenueSummaryRepository;
+import kr.co.abacus.abms.adapter.infrastructure.summary.CompanyMonthlyCostSummaryRepository;
 import kr.co.abacus.abms.application.auth.outbound.AccountRepository;
 import kr.co.abacus.abms.application.department.outbound.DepartmentRepository;
 import kr.co.abacus.abms.application.employee.outbound.EmployeeRepository;
@@ -35,6 +36,7 @@ import kr.co.abacus.abms.domain.employee.EmployeeGrade;
 import kr.co.abacus.abms.domain.employee.EmployeePosition;
 import kr.co.abacus.abms.domain.employee.EmployeeType;
 import kr.co.abacus.abms.domain.shared.Money;
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummaryCreateRequest;
 import kr.co.abacus.abms.support.ApiIntegrationTestBase;
@@ -59,6 +61,9 @@ class MonthlyRevenueSummaryApiTest extends ApiIntegrationTestBase {
 
     @Autowired
     private MonthlyRevenueSummaryRepository monthlyRevenueSummaryRepository;
+
+    @Autowired
+    private CompanyMonthlyCostSummaryRepository companyMonthlyCostSummaryRepository;
 
     private Long departmentId;
 
@@ -98,6 +103,12 @@ class MonthlyRevenueSummaryApiTest extends ApiIntegrationTestBase {
         monthlyRevenueSummaryRepository.save(createSummary(1L, "SUMMARY-PRJ-01", "2025-12-31", 88_000_000L, 44_000_000L));
         monthlyRevenueSummaryRepository.save(createSummary(1L, "SUMMARY-PRJ-01", "2026-01-31", 90_000_000L, 45_000_000L));
         monthlyRevenueSummaryRepository.save(createSummary(2L, "SUMMARY-PRJ-02", "2026-01-20", 10_000_000L, 5_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2025-08-01", 70_000_000L, 40_000_000L, 10_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2025-09-01", 72_000_000L, 41_000_000L, 11_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2025-10-01", 74_000_000L, 42_000_000L, 12_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2025-11-01", 76_000_000L, 43_000_000L, 13_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2025-12-01", 78_000_000L, 44_000_000L, 14_000_000L));
+        companyMonthlyCostSummaryRepository.save(createCompanyCostSummary("2026-01-01", 80_000_000L, 45_000_000L, 15_000_000L));
         flushAndClear();
     }
 
@@ -150,6 +161,62 @@ class MonthlyRevenueSummaryApiTest extends ApiIntegrationTestBase {
                 .andExpect(jsonPath("$[5].revenue").value(100_000_000));
     }
 
+    @Test
+    @DisplayName("기준 월의 전사 월 손익을 조회한다")
+    void getCompanyMonthlyCostSummary() throws Exception {
+        MockHttpSession session = login();
+
+        mockMvc.perform(get("/api/companyMonthlyCostSummary")
+                        .param("yearMonth", "202601")
+                        .session(session))
+                .andDo(document("company-monthly-cost-summary/get",
+                        queryParameters(
+                                parameterWithName("yearMonth").description("조회 기준 월(yyyyMM)")
+                        ),
+                        responseFields(
+                                fieldWithPath("targetMonth").description("집계 대상 월의 기준일"),
+                                fieldWithPath("revenue").description("프로젝트 매출 합계"),
+                                fieldWithPath("projectAllocatedCost").description("프로젝트 배부 비용 합계"),
+                                fieldWithPath("unallocatedEmployeeCost").description("비가용 정직원 비용"),
+                                fieldWithPath("cost").description("전사 월 비용"),
+                                fieldWithPath("profit").description("전사 월 이익")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.targetMonth").value("2026-01-01"))
+                .andExpect(jsonPath("$.revenue").value(100_000_000))
+                .andExpect(jsonPath("$.projectAllocatedCost").value(50_000_000))
+                .andExpect(jsonPath("$.unallocatedEmployeeCost").value(15_000_000))
+                .andExpect(jsonPath("$.cost").value(65_000_000))
+                .andExpect(jsonPath("$.profit").value(35_000_000));
+    }
+
+    @Test
+    @DisplayName("기준 월 포함 최근 6개월 전사 월 손익 추이를 조회한다")
+    void getCompanyMonthlyCostSixMonthTrend() throws Exception {
+        MockHttpSession session = login();
+
+        mockMvc.perform(get("/api/companyMonthlyCostSummary/sixMonthTrend")
+                        .param("yearMonth", "202601")
+                        .session(session))
+                .andDo(document("company-monthly-cost-summary/six-month-trend",
+                        queryParameters(
+                                parameterWithName("yearMonth").description("조회 기준 월(yyyyMM)")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].targetMonth").description("집계 대상 월의 기준일"),
+                                fieldWithPath("[].revenue").description("프로젝트 매출 합계"),
+                                fieldWithPath("[].projectAllocatedCost").description("프로젝트 배부 비용 합계"),
+                                fieldWithPath("[].unallocatedEmployeeCost").description("비가용 정직원 비용"),
+                                fieldWithPath("[].cost").description("전사 월 비용"),
+                                fieldWithPath("[].profit").description("전사 월 이익")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].targetMonth").value("2025-08-01"))
+                .andExpect(jsonPath("$[0].cost").value(50_000_000))
+                .andExpect(jsonPath("$[5].targetMonth").value("2026-01-01"))
+                .andExpect(jsonPath("$[5].cost").value(65_000_000));
+    }
+
     private MockHttpSession login() throws Exception {
         MvcResult loginResult = mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -178,6 +245,20 @@ class MonthlyRevenueSummaryApiTest extends ApiIntegrationTestBase {
                 Money.wons(cost),
                 Money.wons(revenue - cost)
         ));
+    }
+
+    private CompanyMonthlyCostSummary createCompanyCostSummary(
+            String targetMonth,
+            long totalFullTimeCost,
+            long allocatedFullTimeCost,
+            long unallocatedFullTimeCost
+    ) {
+        return CompanyMonthlyCostSummary.create(
+                LocalDate.parse(targetMonth),
+                Money.wons(totalFullTimeCost),
+                Money.wons(allocatedFullTimeCost),
+                Money.wons(unallocatedFullTimeCost)
+        );
     }
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/employee/outbound/EmployeeMonthlyCostRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/employee/outbound/EmployeeMonthlyCostRepository.java
@@ -9,6 +9,8 @@ public interface EmployeeMonthlyCostRepository {
 
     Optional<EmployeeMonthlyCost> findByEmployeeIdAndCostMonth(Long employeeId, String costMonth);
 
+    List<EmployeeMonthlyCost> findAllByCostMonthAndDeletedFalse(String costMonth);
+
     <S extends EmployeeMonthlyCost> List<S> saveAll(Iterable<S> employeeMonthlyCosts);
 
 }

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/summary/CompanyMonthlyCostSummaryQueryService.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/summary/CompanyMonthlyCostSummaryQueryService.java
@@ -1,0 +1,94 @@
+package kr.co.abacus.abms.application.summary;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.co.abacus.abms.application.summary.inbound.CompanyMonthlyCostSummaryFinder;
+import kr.co.abacus.abms.application.summary.outbound.CompanyMonthlyCostSummaryRepository;
+import kr.co.abacus.abms.application.summary.outbound.MonthlyRevenueSummaryRepository;
+import kr.co.abacus.abms.domain.shared.Money;
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummaryTotal;
+import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummary;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CompanyMonthlyCostSummaryQueryService implements CompanyMonthlyCostSummaryFinder {
+
+    private final CompanyMonthlyCostSummaryRepository companyMonthlyCostSummaryRepository;
+    private final MonthlyRevenueSummaryRepository monthlyRevenueSummaryRepository;
+
+    @Override
+    public CompanyMonthlyCostSummaryTotal findByTargetMonth(String yearMonthStr) {
+        LocalDate targetMonth = parseYearMonth(yearMonthStr).atDay(1);
+        CompanyMonthlyCostSummary costSummary = companyMonthlyCostSummaryRepository
+                .findByTargetMonthAndDeletedFalse(targetMonth)
+                .orElseThrow(() -> new IllegalArgumentException("계산되지 않은 전사 월 비용 집계: " + yearMonthStr));
+        List<MonthlyRevenueSummary> revenueSummaries = monthlyRevenueSummaryRepository
+                .findAllByTargetMonthAndDeletedFalseOrderByProjectIdAsc(targetMonth);
+
+        return toTotal(costSummary, revenueSummaries);
+    }
+
+    @Override
+    public List<CompanyMonthlyCostSummaryTotal> findRecentSixMonths(String yearMonthStr) {
+        YearMonth targetYearMonth = parseYearMonth(yearMonthStr);
+        LocalDate startMonth = targetYearMonth.minusMonths(5).atDay(1);
+        LocalDate endMonth = targetYearMonth.atDay(1);
+        List<CompanyMonthlyCostSummary> costSummaries = companyMonthlyCostSummaryRepository
+                .findAllByTargetMonthBetweenAndDeletedFalseOrderByTargetMonthAsc(startMonth, endMonth);
+        List<MonthlyRevenueSummary> revenueSummaries = monthlyRevenueSummaryRepository
+                .findAllByTargetMonthBetweenAndDeletedFalseOrderByTargetMonthAscProjectIdAsc(startMonth, endMonth);
+
+        List<CompanyMonthlyCostSummaryTotal> totals = new ArrayList<>();
+        for (int i = 5; i >= 0; i--) {
+            LocalDate currentMonth = targetYearMonth.minusMonths(i).atDay(1);
+            costSummaries.stream()
+                    .filter(summary -> summary.getTargetMonth().isEqual(currentMonth))
+                    .findFirst()
+                    .map(summary -> toTotal(summary, revenueSummaries.stream()
+                            .filter(revenueSummary -> revenueSummary.getTargetMonth().isEqual(currentMonth))
+                            .toList()))
+                    .ifPresent(totals::add);
+        }
+
+        return totals;
+    }
+
+    private YearMonth parseYearMonth(String yearMonthStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+        return YearMonth.parse(yearMonthStr, formatter);
+    }
+
+    private CompanyMonthlyCostSummaryTotal toTotal(
+            CompanyMonthlyCostSummary costSummary,
+            List<MonthlyRevenueSummary> revenueSummaries
+    ) {
+        Money revenue = revenueSummaries.stream()
+                .map(MonthlyRevenueSummary::getRevenueAmount)
+                .reduce(Money.zero(), Money::add);
+        Money projectAllocatedCost = revenueSummaries.stream()
+                .map(MonthlyRevenueSummary::getCostAmount)
+                .reduce(Money.zero(), Money::add);
+        Money unallocatedCost = costSummary.getUnallocatedFullTimeEmployeeCost();
+        Money cost = projectAllocatedCost.add(unallocatedCost);
+        Money profit = revenue.subtract(cost);
+
+        return new CompanyMonthlyCostSummaryTotal(
+                costSummary.getTargetMonth(),
+                revenue,
+                projectAllocatedCost,
+                unallocatedCost,
+                cost,
+                profit
+        );
+    }
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/summary/inbound/CompanyMonthlyCostSummaryFinder.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/summary/inbound/CompanyMonthlyCostSummaryFinder.java
@@ -1,0 +1,12 @@
+package kr.co.abacus.abms.application.summary.inbound;
+
+import java.util.List;
+
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummaryTotal;
+
+public interface CompanyMonthlyCostSummaryFinder {
+
+    CompanyMonthlyCostSummaryTotal findByTargetMonth(String yearMonthStr);
+
+    List<CompanyMonthlyCostSummaryTotal> findRecentSixMonths(String yearMonthStr);
+}

--- a/abms-application/src/main/java/kr/co/abacus/abms/application/summary/outbound/CompanyMonthlyCostSummaryRepository.java
+++ b/abms-application/src/main/java/kr/co/abacus/abms/application/summary/outbound/CompanyMonthlyCostSummaryRepository.java
@@ -1,0 +1,19 @@
+package kr.co.abacus.abms.application.summary.outbound;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
+
+public interface CompanyMonthlyCostSummaryRepository {
+
+    Optional<CompanyMonthlyCostSummary> findByTargetMonthAndDeletedFalse(LocalDate targetMonth);
+
+    List<CompanyMonthlyCostSummary> findAllByTargetMonthBetweenAndDeletedFalseOrderByTargetMonthAsc(
+            LocalDate start,
+            LocalDate end
+    );
+
+    <S extends CompanyMonthlyCostSummary> List<S> saveAll(Iterable<S> summaries);
+}

--- a/abms-batch-boot/src/test/java/kr/co/abacus/abms/adapter/batch/BatchJobStructureTest.java
+++ b/abms-batch-boot/src/test/java/kr/co/abacus/abms/adapter/batch/BatchJobStructureTest.java
@@ -55,7 +55,9 @@ import kr.co.abacus.abms.domain.project.RevenueType;
 import kr.co.abacus.abms.domain.projectassignment.AssignmentRole;
 import kr.co.abacus.abms.domain.projectassignment.ProjectAssignment;
 import kr.co.abacus.abms.domain.projectassignment.ProjectAssignmentCreateRequest;
+import kr.co.abacus.abms.domain.projectassignment.ProjectAssignmentUpdateRequest;
 import kr.co.abacus.abms.domain.shared.Money;
+import kr.co.abacus.abms.domain.summary.CompanyMonthlyCostSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummary;
 import kr.co.abacus.abms.domain.summary.MonthlyRevenueSummaryCreateRequest;
 import kr.co.abacus.abms.domain.summary.RevenueMonthClosing;
@@ -123,6 +125,9 @@ class BatchJobStructureTest {
 
     @Autowired
     private kr.co.abacus.abms.adapter.infrastructure.summary.MonthlyRevenueSummaryRepository monthlyRevenueSummaryRepository;
+
+    @Autowired
+    private kr.co.abacus.abms.adapter.infrastructure.summary.CompanyMonthlyCostSummaryRepository companyMonthlyCostSummaryRepository;
 
     @Autowired
     private kr.co.abacus.abms.adapter.infrastructure.summary.RevenueMonthClosingRepository revenueMonthClosingRepository;
@@ -500,6 +505,118 @@ class BatchJobStructureTest {
     }
 
     @Test
+    @DisplayName("revenueMonthlySummaryJob는 정직원 비가용 비용을 전사 월 비용으로 집계한다")
+    void revenueMonthlySummaryJob_aggregatesCompanyMonthlyCostSummary() throws Exception {
+        LocalDate targetDate = LocalDate.of(2026, 8, 15);
+        Department leadDepartment = createDepartment("전사원가팀");
+        Employee fullTimeAssigned = createEmployee(leadDepartment, "정직A", "batch-company-a@abms.co.kr");
+        Employee fullTimeUnassigned = createEmployee(leadDepartment, "정직B", "batch-company-b@abms.co.kr");
+        Employee freelancerAssigned = createEmployee(leadDepartment, "프리C", "batch-company-c@abms.co.kr", EmployeeType.FREELANCER);
+        Party party = partyRepository.save(Party.create(new PartyCreateRequest("전사원가협력사", null, null, null, null)));
+        Project project = projectRepository.save(Project.create(
+                party.getIdOrThrow(),
+                leadDepartment.getIdOrThrow(),
+                "BATCH-COMP-001",
+                "전사 원가 프로젝트",
+                null,
+                ProjectStatus.IN_PROGRESS,
+                100_000_000L,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31)
+        ));
+
+        ProjectRevenuePlan issuedPlan = ProjectRevenuePlan.create(new ProjectRevenuePlanCreateRequest(
+                project.getIdOrThrow(),
+                1,
+                LocalDate.of(2026, 8, 20),
+                RevenueType.INTERMEDIATE_PAYMENT,
+                50_000_000L,
+                "전사 원가 매출"
+        ));
+        issuedPlan.issue();
+        projectRevenuePlanRepository.save(issuedPlan);
+
+        ProjectAssignment fullTimeAssignment = projectAssignmentRepository.save(ProjectAssignment.assign(project, new ProjectAssignmentCreateRequest(
+                project.getIdOrThrow(),
+                fullTimeAssigned.getIdOrThrow(),
+                AssignmentRole.DEV,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 16)
+        )));
+        projectAssignmentRepository.save(ProjectAssignment.assign(project, new ProjectAssignmentCreateRequest(
+                project.getIdOrThrow(),
+                freelancerAssigned.getIdOrThrow(),
+                AssignmentRole.DEV,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31)
+        )));
+        employeeMonthlyCostRepository.save(EmployeeMonthlyCost.create(
+                fullTimeAssigned.getIdOrThrow(),
+                "202608",
+                Money.wons(10_000_000L),
+                Money.zero(),
+                Money.zero(),
+                Money.wons(10_000_000L)
+        ));
+        employeeMonthlyCostRepository.save(EmployeeMonthlyCost.create(
+                fullTimeUnassigned.getIdOrThrow(),
+                "202608",
+                Money.wons(8_000_000L),
+                Money.zero(),
+                Money.zero(),
+                Money.wons(8_000_000L)
+        ));
+        employeeMonthlyCostRepository.save(EmployeeMonthlyCost.create(
+                freelancerAssigned.getIdOrThrow(),
+                "202608",
+                Money.wons(6_000_000L),
+                Money.zero(),
+                Money.zero(),
+                Money.wons(6_000_000L)
+        ));
+        flushAndClear();
+
+        JobExecution firstExecution = jobLauncher.run(revenueMonthlySummaryJob, jobParameters(targetDate, 10L));
+
+        assertThat(firstExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        MonthlyRevenueSummary firstProjectSummary = findSummary(project, LocalDate.of(2026, 8, 1));
+        assertThat(firstProjectSummary.getRevenueAmount().amount().longValue()).isEqualTo(50_000_000L);
+        assertThat(firstProjectSummary.getCostAmount().amount().longValue()).isEqualTo(11_000_000L);
+
+        CompanyMonthlyCostSummary firstCompanySummary = companyMonthlyCostSummaryRepository
+                .findByTargetMonthAndDeletedFalse(LocalDate.of(2026, 8, 1))
+                .orElseThrow();
+        Long firstCompanySummaryId = firstCompanySummary.getIdOrThrow();
+        assertThat(firstCompanySummary.getTotalFullTimeEmployeeCost().amount().longValue()).isEqualTo(18_000_000L);
+        assertThat(firstCompanySummary.getAllocatedFullTimeEmployeeCost().amount().longValue()).isEqualTo(5_000_000L);
+        assertThat(firstCompanySummary.getUnallocatedFullTimeEmployeeCost().amount().longValue()).isEqualTo(13_000_000L);
+
+        ProjectAssignment reloadedAssignment = projectAssignmentRepository.findById(fullTimeAssignment.getIdOrThrow()).orElseThrow();
+        reloadedAssignment.update(project, new ProjectAssignmentUpdateRequest(
+                fullTimeAssigned.getIdOrThrow(),
+                AssignmentRole.DEV,
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 8, 31)
+        ));
+        projectAssignmentRepository.save(reloadedAssignment);
+        flushAndClear();
+
+        JobExecution secondExecution = jobLauncher.run(revenueMonthlySummaryJob, jobParameters(targetDate, 11L));
+
+        assertThat(secondExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        assertThat(companyMonthlyCostSummaryRepository.findAll().stream()
+                .filter(summary -> summary.getTargetMonth().isEqual(LocalDate.of(2026, 8, 1)))
+                .toList()).hasSize(1);
+        CompanyMonthlyCostSummary updatedCompanySummary = companyMonthlyCostSummaryRepository
+                .findByTargetMonthAndDeletedFalse(LocalDate.of(2026, 8, 1))
+                .orElseThrow();
+        assertThat(updatedCompanySummary.getIdOrThrow()).isEqualTo(firstCompanySummaryId);
+        assertThat(updatedCompanySummary.getAllocatedFullTimeEmployeeCost().amount().longValue()).isEqualTo(10_000_000L);
+        assertThat(updatedCompanySummary.getUnallocatedFullTimeEmployeeCost().amount().longValue()).isEqualTo(8_000_000L);
+        assertThat(findSummary(project, LocalDate.of(2026, 8, 1)).getCostAmount().amount().longValue()).isEqualTo(16_000_000L);
+    }
+
+    @Test
     @DisplayName("revenueMonthlySummaryJob는 마감 월을 자동 재계산하지 않는다")
     void revenueMonthlySummaryJob_skipsClosedMonth() throws Exception {
         LocalDate targetDate = LocalDate.of(2026, 4, 15);
@@ -528,6 +645,12 @@ class BatchJobStructureTest {
                 Money.wons(1_000_000L),
                 Money.wons(9_000_000L)
         )));
+        companyMonthlyCostSummaryRepository.save(CompanyMonthlyCostSummary.create(
+                LocalDate.of(2026, 4, 1),
+                Money.wons(20_000_000L),
+                Money.wons(3_000_000L),
+                Money.wons(17_000_000L)
+        ));
         revenueMonthClosingRepository.save(RevenueMonthClosing.close(LocalDate.of(2026, 4, 1), null));
 
         ProjectRevenuePlan issuedPlan = ProjectRevenuePlan.create(new ProjectRevenuePlanCreateRequest(
@@ -549,6 +672,11 @@ class BatchJobStructureTest {
                 .findByProjectIdAndTargetMonthAndDeletedFalse(project.getIdOrThrow(), LocalDate.of(2026, 4, 1))
                 .orElseThrow();
         assertThat(summary.getRevenueAmount().amount().longValue()).isEqualTo(10_000_000L);
+        CompanyMonthlyCostSummary companySummary = companyMonthlyCostSummaryRepository
+                .findByTargetMonthAndDeletedFalse(LocalDate.of(2026, 4, 1))
+                .orElseThrow();
+        assertThat(companySummary.getTotalFullTimeEmployeeCost().amount().longValue()).isEqualTo(20_000_000L);
+        assertThat(companySummary.getUnallocatedFullTimeEmployeeCost().amount().longValue()).isEqualTo(17_000_000L);
     }
 
     private JobParameters jobParameters(LocalDate targetDate, long runId) {
@@ -590,6 +718,10 @@ class BatchJobStructureTest {
     }
 
     private Employee createEmployee(Department department, String name, String email) {
+        return createEmployee(department, name, email, EmployeeType.FULL_TIME);
+    }
+
+    private Employee createEmployee(Department department, String name, String email, EmployeeType type) {
         return employeeRepository.save(Employee.create(
                 department.getIdOrThrow(),
                 name,
@@ -597,7 +729,7 @@ class BatchJobStructureTest {
                 LocalDate.of(2024, 1, 1),
                 LocalDate.of(1990, 5, 20),
                 EmployeePosition.ASSOCIATE,
-                EmployeeType.FULL_TIME,
+                type,
                 EmployeeGrade.JUNIOR,
                 EmployeeAvatar.SKY_GLOW,
                 null

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/summary/CompanyMonthlyCostSummary.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/summary/CompanyMonthlyCostSummary.java
@@ -1,0 +1,82 @@
+package kr.co.abacus.abms.domain.summary;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Objects;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import kr.co.abacus.abms.domain.AbstractEntity;
+import kr.co.abacus.abms.domain.shared.Money;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "tb_company_monthly_cost_summary",
+        uniqueConstraints = @UniqueConstraint(
+                name = "UK_COMPANY_MONTHLY_COST_SUMMARY_TARGET_MONTH",
+                columnNames = "target_month"
+        ),
+        indexes = @Index(name = "IDX_COMPANY_MONTHLY_COST_SUMMARY_TARGET_MONTH", columnList = "target_month")
+)
+public class CompanyMonthlyCostSummary extends AbstractEntity {
+
+    @Column(name = "target_month", nullable = false, comment = "집계대상월")
+    private LocalDate targetMonth;
+
+    @Column(name = "calculated_at", nullable = false, comment = "집계계산일시")
+    private LocalDateTime calculatedAt;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "total_full_time_employee_cost", nullable = false, comment = "정직원 월 원가 합계"))
+    private Money totalFullTimeEmployeeCost;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "allocated_full_time_employee_cost", nullable = false, comment = "정직원 프로젝트 배부 원가"))
+    private Money allocatedFullTimeEmployeeCost;
+
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "unallocated_full_time_employee_cost", nullable = false, comment = "정직원 비가용 원가"))
+    private Money unallocatedFullTimeEmployeeCost;
+
+    public static CompanyMonthlyCostSummary create(
+            LocalDate targetMonth,
+            Money totalFullTimeEmployeeCost,
+            Money allocatedFullTimeEmployeeCost,
+            Money unallocatedFullTimeEmployeeCost
+    ) {
+        CompanyMonthlyCostSummary summary = new CompanyMonthlyCostSummary();
+        summary.targetMonth = normalizeTargetMonth(targetMonth);
+        summary.totalFullTimeEmployeeCost = Objects.requireNonNull(totalFullTimeEmployeeCost);
+        summary.allocatedFullTimeEmployeeCost = Objects.requireNonNull(allocatedFullTimeEmployeeCost);
+        summary.unallocatedFullTimeEmployeeCost = Objects.requireNonNull(unallocatedFullTimeEmployeeCost);
+        summary.calculatedAt = LocalDateTime.now();
+        return summary;
+    }
+
+    public void update(
+            Money totalFullTimeEmployeeCost,
+            Money allocatedFullTimeEmployeeCost,
+            Money unallocatedFullTimeEmployeeCost
+    ) {
+        this.totalFullTimeEmployeeCost = Objects.requireNonNull(totalFullTimeEmployeeCost);
+        this.allocatedFullTimeEmployeeCost = Objects.requireNonNull(allocatedFullTimeEmployeeCost);
+        this.unallocatedFullTimeEmployeeCost = Objects.requireNonNull(unallocatedFullTimeEmployeeCost);
+        this.calculatedAt = LocalDateTime.now();
+    }
+
+    private static LocalDate normalizeTargetMonth(LocalDate targetMonth) {
+        return YearMonth.from(Objects.requireNonNull(targetMonth)).atDay(1);
+    }
+}

--- a/abms-domain/src/main/java/kr/co/abacus/abms/domain/summary/CompanyMonthlyCostSummaryTotal.java
+++ b/abms-domain/src/main/java/kr/co/abacus/abms/domain/summary/CompanyMonthlyCostSummaryTotal.java
@@ -1,0 +1,15 @@
+package kr.co.abacus.abms.domain.summary;
+
+import java.time.LocalDate;
+
+import kr.co.abacus.abms.domain.shared.Money;
+
+public record CompanyMonthlyCostSummaryTotal(
+        LocalDate targetMonth,
+        Money revenueAmount,
+        Money projectAllocatedCostAmount,
+        Money unallocatedEmployeeCostAmount,
+        Money costAmount,
+        Money profitAmount
+) {
+}


### PR DESCRIPTION
## 변경 요약
- 전사 월 비용 집계 모델과 `tb_company_monthly_cost_summary` 마이그레이션을 추가했습니다.
- 매출 집계 배치가 대상 월마다 정직원 총 원가, 정직원 프로젝트 배부 원가, 비가용 정직원 원가를 멱등하게 upsert하도록 했습니다.
- 기존 `/api/monthlyRevenueSummary`는 유지하고, 전사 기준 월 손익 조회용 `/api/companyMonthlyCostSummary` API를 추가했습니다.

## 관련 이슈 (필수)
- Closes #104
- Refs #97
- Refs #102

## 핵심 검증 (필수)
- [x] 로컬에서 핵심 시나리오를 검증했다.
- 검증 내용 요약:
  - `./gradlew :abms-batch-boot:test --tests "*BatchJobStructureTest" :abms-api-boot:test --tests "*MonthlyRevenueSummaryApiTest"`
  - `./gradlew test`

## 증빙 자료 (조건부 필수)
- [x] UI 변경 없음 (해당 시 아래 생략 가능)
- [ ] UI 변경 있음: Before/After 캡처 첨부
- [ ] 동작 흐름 확인 필요: 짧은 영상(GIF/MP4) 첨부
- 첨부 링크/설명:
  - 없음

## 영향도 (필수)
- API 변경: [x] 있음 [ ] 없음
- DB 스키마/데이터 마이그레이션: [x] 있음 [ ] 없음
- ENV 변수 추가/변경: [ ] 있음 [x] 없음

## 리뷰/머지 체크
- [ ] 팀원 1명 승인 완료
- [ ] CI 체크 통과

## Hotfix 예외
- [ ] 이 PR은 `hotfix/*` 이다. (체크 시 셀프 머지 허용)
- [ ] 사후 리뷰 이슈를 생성했고 24시간 내 리뷰한다.